### PR TITLE
fix(message): replace Node.js Buffer with universal base64 helpers

### DIFF
--- a/packages/agentscope/package.json
+++ b/packages/agentscope/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@agentscope-ai/agentscope",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "description": "",
     "exports": {
         "./message": {

--- a/packages/agentscope/src/_utils/common.ts
+++ b/packages/agentscope/src/_utils/common.ts
@@ -3,6 +3,29 @@ import { jsonrepair } from 'jsonrepair';
 import { JSONSerializableObject } from '../type';
 
 /**
+ * Decode a base64 string to a Uint8Array.
+ * Works in both Node.js and browser environments.
+ * @param b64
+ */
+export function base64ToBytes(b64: string): Uint8Array {
+    const binary = atob(b64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+}
+
+/**
+ * Encode a Uint8Array to a base64 string.
+ * Works in both Node.js and browser environments.
+ * @param bytes
+ */
+export function bytesToBase64(bytes: Uint8Array): string {
+    let binary = '';
+    for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+    return btoa(binary);
+}
+
+/**
  * Creates a timestamp string in the format "YYYY-MM-DD HH:mm:ss.sss"
  * representing the current date and time.
  *

--- a/packages/agentscope/src/_utils/common.ts
+++ b/packages/agentscope/src/_utils/common.ts
@@ -6,6 +6,7 @@ import { JSONSerializableObject } from '../type';
  * Decode a base64 string to a Uint8Array.
  * Works in both Node.js and browser environments.
  * @param b64
+ * @returns The decoded bytes.
  */
 export function base64ToBytes(b64: string): Uint8Array {
     const binary = atob(b64);
@@ -18,6 +19,7 @@ export function base64ToBytes(b64: string): Uint8Array {
  * Encode a Uint8Array to a base64 string.
  * Works in both Node.js and browser environments.
  * @param bytes
+ * @returns The base64-encoded string.
  */
 export function bytesToBase64(bytes: Uint8Array): string {
     let binary = '';

--- a/packages/agentscope/src/message/message.ts
+++ b/packages/agentscope/src/message/message.ts
@@ -10,6 +10,7 @@ import {
     Base64Source,
     URLSource,
 } from './block';
+import { base64ToBytes, bytesToBase64 } from '../_utils/common';
 import { AgentEvent, EventType } from '../event';
 
 /** A chat message exchanged between agents or between an agent and a model. */
@@ -349,9 +350,12 @@ export function appendEvent(msg: Msg, event: AgentEvent): Msg {
                 // the middle of the byte stream and corrupt it. Decode, concat
                 // bytes, re-encode.
                 const src = (block as DataBlock).source as Base64Source;
-                const existing = src.data ? Buffer.from(src.data, 'base64') : Buffer.alloc(0);
-                const incoming = Buffer.from(event.data, 'base64');
-                src.data = Buffer.concat([existing, incoming]).toString('base64');
+                const existing = src.data ? base64ToBytes(src.data) : new Uint8Array(0);
+                const incoming = base64ToBytes(event.data);
+                const merged = new Uint8Array(existing.length + incoming.length);
+                merged.set(existing, 0);
+                merged.set(incoming, existing.length);
+                src.data = bytesToBase64(merged);
             }
             break;
         }


### PR DESCRIPTION
## Description

Replace  `Buffer.from/Buffer.concat` in `appendEvent` with `atob/btoa-based` utilities (`base64ToBytes`, `bytesToBase64`) so the message layer works in both Node.js and browser environments.

## Checklist

Please check the following items before the code is ready to be reviewed.

- [ ] This PR is linked to a related issue (see above)
- [ ] Code has been formatted with `pnpm format`
- [ ] Related documentation has been updated (e.g. links, examples, etc.)
- [ ] All tests are passing (`pnpm test`)
- [ ] Code is ready for review
