### PR TITLE
feat(model): add kimi chat model support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ docs/node_modules
 docs/.next
 docs/.cache
 docs/api-reference/generated
+
+# Local smoke test scripts (contain API keys, not for CI)
+packages/agentscope/src/test/

--- a/packages/agentscope/src/model/kimi-model.test.ts
+++ b/packages/agentscope/src/model/kimi-model.test.ts
@@ -1,0 +1,371 @@
+import { KimiChatModel } from './kimi-model';
+import { ChatResponse } from './response';
+import { createMsg } from '../message';
+
+// Mock fetch for streaming and non-streaming responses
+global.fetch = jest.fn();
+
+describe('KimiChatModel', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('Test stream generation with tool call delta output', async () => {
+        // Mock streaming response with multiple chunks (OpenAI-compatible SSE format)
+        const mockStreamChunks = [
+            'data: {"id":"chatcmpl-kimi-1","object":"chat.completion.chunk","created":1700000000,"model":"kimi-k2-turbo-preview","choices":[{"index":0,"delta":{"content":"Let me check"},"finish_reason":null}]}\n\n',
+            'data: {"id":"chatcmpl-kimi-1","object":"chat.completion.chunk","created":1700000000,"model":"kimi-k2-turbo-preview","choices":[{"index":0,"delta":{"content":" the weather."},"finish_reason":null}]}\n\n',
+            'data: {"id":"chatcmpl-kimi-1","object":"chat.completion.chunk","created":1700000000,"model":"kimi-k2-turbo-preview","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call-kimi-1","type":"function","function":{"name":"get_current_weather","arguments":"{\\"location\\""}}]},"finish_reason":null}]}\n\n',
+            'data: {"id":"chatcmpl-kimi-1","object":"chat.completion.chunk","created":1700000000,"model":"kimi-k2-turbo-preview","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":":\\"Beijing\\"}"}}]},"finish_reason":null}]}\n\n',
+            'data: {"id":"chatcmpl-kimi-1","object":"chat.completion.chunk","created":1700000000,"model":"kimi-k2-turbo-preview","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":80,"completion_tokens":40,"total_tokens":120}}\n\n',
+            'data: [DONE]\n\n',
+        ];
+
+        const mockReadableStream = new ReadableStream({
+            start(controller) {
+                mockStreamChunks.forEach(chunk =>
+                    controller.enqueue(new TextEncoder().encode(chunk))
+                );
+                controller.close();
+            },
+        });
+
+        (global.fetch as jest.Mock).mockResolvedValue({
+            ok: true,
+            body: mockReadableStream,
+        });
+
+        const model = new KimiChatModel({
+            modelName: 'kimi-k2-turbo-preview',
+            apiKey: 'test-api-key',
+        });
+
+        const res = await model.call({
+            messages: [
+                createMsg({
+                    name: 'user',
+                    role: 'user',
+                    content: [{ id: crypto.randomUUID(), type: 'text', text: '查询北京天气' }],
+                }),
+            ],
+            tools: [
+                {
+                    type: 'function',
+                    function: {
+                        name: 'get_current_weather',
+                        description: 'Get the current weather in a given location',
+                        parameters: {
+                            type: 'object',
+                            properties: {
+                                location: {
+                                    type: 'string',
+                                    description: 'The city and state, e.g. San Francisco, CA',
+                                },
+                            },
+                            required: ['location'],
+                        },
+                    },
+                },
+            ],
+        });
+
+        const generator = res as AsyncGenerator<ChatResponse, ChatResponse>;
+        let completeResponse: ChatResponse | undefined;
+        const yieldedChunks: ChatResponse[] = [];
+
+        // Manually iterate to capture both yielded and returned values
+        while (true) {
+            const result = await generator.next();
+            if (result.done) {
+                completeResponse = result.value;
+                break;
+            }
+            yieldedChunks.push(result.value);
+        }
+
+        // Verify we received multiple yielded chunks
+        expect(yieldedChunks.length).toBeGreaterThan(0);
+
+        // Verify the final complete response has correct structure
+        expect(completeResponse.content.length).toBe(2);
+
+        // Check text block - should be accumulated across chunks
+        const textBlock = completeResponse.content.find(b => b.type === 'text');
+        expect(textBlock).toBeDefined();
+        expect(textBlock).toMatchObject({
+            type: 'text',
+            text: 'Let me check the weather.',
+        });
+
+        // Check tool_call block - input should be complete after accumulation
+        const toolCallBlock = completeResponse.content.find(b => b.type === 'tool_call');
+        expect(toolCallBlock).toBeDefined();
+        expect(toolCallBlock).toMatchObject({
+            type: 'tool_call',
+            name: 'get_current_weather',
+            id: 'call-kimi-1',
+            input: '{"location":"Beijing"}',
+            state: 'pending',
+        });
+
+        // Verify usage
+        expect(completeResponse.usage).toBeDefined();
+        expect(completeResponse.usage?.inputTokens).toBe(80);
+        expect(completeResponse.usage?.outputTokens).toBe(40);
+
+        // Verify the request went to the default OpenAI-compatible endpoint
+        expect(global.fetch).toHaveBeenCalledWith(
+            'https://api.kimi.com/coding/v1/chat/completions',
+            expect.objectContaining({
+                method: 'POST',
+                headers: expect.objectContaining({
+                    Authorization: 'Bearer test-api-key',
+                    'Content-Type': 'application/json',
+                }),
+            })
+        );
+    }, 10000);
+
+    test('Test non-streaming generation with tool call response', async () => {
+        // Mock non-streaming response (OpenAI-compatible)
+        const mockResponse = {
+            id: 'chatcmpl-kimi-2',
+            object: 'chat.completion',
+            created: 1700000000,
+            model: 'kimi-k2-turbo-preview',
+            choices: [
+                {
+                    index: 0,
+                    message: {
+                        role: 'assistant',
+                        content: null,
+                        tool_calls: [
+                            {
+                                id: 'call-kimi-2',
+                                type: 'function',
+                                function: {
+                                    name: 'get_current_weather',
+                                    arguments: '{"location":"Beijing"}',
+                                },
+                            },
+                        ],
+                    },
+                    finish_reason: 'tool_calls',
+                },
+            ],
+            usage: {
+                prompt_tokens: 80,
+                completion_tokens: 40,
+                total_tokens: 120,
+            },
+        };
+
+        (global.fetch as jest.Mock).mockResolvedValue({
+            ok: true,
+            json: async () => mockResponse,
+        });
+
+        const model = new KimiChatModel({
+            modelName: 'kimi-k2-turbo-preview',
+            apiKey: 'test-api-key',
+            stream: false,
+        });
+
+        const res = await model.call({
+            messages: [
+                createMsg({
+                    name: 'user',
+                    role: 'user',
+                    content: [{ id: crypto.randomUUID(), type: 'text', text: '查询北京天气' }],
+                }),
+            ],
+            tools: [
+                {
+                    type: 'function',
+                    function: {
+                        name: 'get_current_weather',
+                        description: 'Get the current weather in a given location',
+                        parameters: {
+                            type: 'object',
+                            properties: {
+                                location: {
+                                    type: 'string',
+                                    description: 'The city and state, e.g. San Francisco, CA',
+                                },
+                            },
+                            required: ['location'],
+                        },
+                    },
+                },
+            ],
+        });
+
+        const completeResponse = res as ChatResponse;
+
+        // Verify complete response structure - only one tool_call block
+        expect(completeResponse.content.length).toBe(1);
+
+        const toolCallBlock = completeResponse.content.find(b => b.type === 'tool_call');
+        expect(toolCallBlock).toBeDefined();
+        expect(toolCallBlock).toMatchObject({
+            type: 'tool_call',
+            name: 'get_current_weather',
+            id: 'call-kimi-2',
+            input: '{"location":"Beijing"}',
+            state: 'pending',
+        });
+
+        // Verify usage
+        expect(completeResponse.usage).toBeDefined();
+        expect(completeResponse.usage?.inputTokens).toBe(80);
+        expect(completeResponse.usage?.outputTokens).toBe(40);
+    }, 10000);
+
+    test('Test formatToolChoice function', () => {
+        const model = new KimiChatModel({
+            modelName: 'kimi-k2-turbo-preview',
+            apiKey: 'test-api-key',
+        });
+
+        // Test 'auto' case
+        expect(model._formatToolChoice('auto')).toBe('auto');
+
+        // Test 'none' case
+        expect(model._formatToolChoice('none')).toBe('none');
+
+        // Test 'required' case
+        expect(model._formatToolChoice('required')).toBe('required');
+
+        // Test specific function name case
+        expect(model._formatToolChoice('get_current_weather')).toEqual({
+            type: 'function',
+            function: {
+                name: 'get_current_weather',
+            },
+        });
+
+        // Test undefined case (should default to 'auto')
+        expect(model._formatToolChoice(undefined)).toBe('auto');
+    });
+
+    test('Test formatToolSchemas function', () => {
+        const model = new KimiChatModel({
+            modelName: 'kimi-k2-turbo-preview',
+            apiKey: 'test-api-key',
+        });
+
+        const toolSchemas = [
+            {
+                type: 'function' as const,
+                function: {
+                    name: 'get_current_weather',
+                    description: 'Get the current weather in a given location',
+                    parameters: {
+                        type: 'object' as const,
+                        properties: {
+                            location: {
+                                type: 'string',
+                                description: 'The city and state, e.g. San Francisco, CA',
+                            },
+                        },
+                        required: ['location'],
+                    },
+                },
+            },
+        ];
+
+        // Test with tool schemas
+        expect(model._formatToolSchemas(toolSchemas)).toEqual(toolSchemas);
+
+        // Test with undefined (should return empty array)
+        expect(model._formatToolSchemas(undefined)).toEqual([]);
+    });
+
+    test('Test endpoint resolution for different protocols and overrides', () => {
+        // Default protocol is OpenAI-compatible
+        const openaiModel = new KimiChatModel({
+            modelName: 'kimi-k2-turbo-preview',
+            apiKey: 'test-api-key',
+        });
+        expect(openaiModel.protocol).toBe('openai');
+        expect(openaiModel.apiURL).toBe('https://api.kimi.com/coding/v1/chat/completions');
+
+        // Anthropic-compatible protocol uses the Messages endpoint
+        const anthropicModel = new KimiChatModel({
+            modelName: 'kimi-k2-turbo-preview',
+            apiKey: 'test-api-key',
+            protocol: 'anthropic',
+        });
+        expect(anthropicModel.protocol).toBe('anthropic');
+        expect(anthropicModel.apiURL).toBe('https://api.kimi.com/coding/v1/messages');
+
+        // Custom baseURL is honored, trailing slash tolerated
+        const customBaseModel = new KimiChatModel({
+            modelName: 'kimi-k2-turbo-preview',
+            apiKey: 'test-api-key',
+            baseURL: 'https://proxy.example.com/kimi/v1/',
+        });
+        expect(customBaseModel.apiURL).toBe('https://proxy.example.com/kimi/v1/chat/completions');
+
+        // Explicit apiURL takes precedence over baseURL/protocol
+        const fullEndpointModel = new KimiChatModel({
+            modelName: 'kimi-k2-turbo-preview',
+            apiKey: 'test-api-key',
+            baseURL: 'https://ignored.example.com',
+            apiURL: 'https://api.kimi.com/coding/v1/chat/completions',
+        });
+        expect(fullEndpointModel.apiURL).toBe('https://api.kimi.com/coding/v1/chat/completions');
+    });
+
+    test('Test Anthropic-protocol request headers', async () => {
+        const mockResponse = {
+            id: 'chatcmpl-kimi-3',
+            object: 'chat.completion',
+            created: 1700000000,
+            model: 'kimi-k2-turbo-preview',
+            choices: [
+                {
+                    index: 0,
+                    message: { role: 'assistant', content: 'hello' },
+                    finish_reason: 'stop',
+                },
+            ],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        };
+
+        (global.fetch as jest.Mock).mockResolvedValue({
+            ok: true,
+            json: async () => mockResponse,
+        });
+
+        const model = new KimiChatModel({
+            modelName: 'kimi-k2-turbo-preview',
+            apiKey: 'test-api-key',
+            protocol: 'anthropic',
+            stream: false,
+        });
+
+        await model.call({
+            messages: [
+                createMsg({
+                    name: 'user',
+                    role: 'user',
+                    content: [{ id: crypto.randomUUID(), type: 'text', text: 'hi' }],
+                }),
+            ],
+        });
+
+        // Anthropic protocol must use x-api-key, not Authorization
+        expect(global.fetch).toHaveBeenCalledWith(
+            'https://api.kimi.com/coding/v1/messages',
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    'x-api-key': 'test-api-key',
+                    'anthropic-version': '2023-06-01',
+                }),
+            })
+        );
+        const call = (global.fetch as jest.Mock).mock.calls[0];
+        expect(call[1].headers).not.toHaveProperty('Authorization');
+    });
+});

--- a/packages/agentscope/src/model/kimi-model.ts
+++ b/packages/agentscope/src/model/kimi-model.ts
@@ -1,0 +1,449 @@
+import { ChatModelBase, ChatModelOptions, ChatModelRequestOptions } from './base';
+import { ChatResponse } from './response';
+import { DataBlock, TextBlock, ThinkingBlock, ToolCallBlock } from '../message';
+import { ToolChoice, ToolSchema } from '../type';
+import { ChatUsage } from './usage';
+import { _parseStreamedResponse } from '../_utils';
+import { OpenAIChatFormatter } from '../formatter';
+
+interface _KimiStreamChunk {
+    choices?: {
+        delta?: {
+            content?: string;
+            reasoning_content?: string;
+            tool_calls?: {
+                index: number;
+                id?: string;
+                function?: {
+                    name?: string;
+                    arguments?: string;
+                };
+            }[];
+        };
+        finish_reason?: string | null;
+    }[];
+    usage?: {
+        prompt_tokens?: number;
+        completion_tokens?: number;
+    };
+}
+
+/**
+ * Wire protocol supported by Kimi Code API.
+ * - `openai`: OpenAI-compatible `chat/completions` endpoint (default).
+ * - `anthropic`: Anthropic-compatible `messages` endpoint.
+ */
+export type KimiProtocol = 'openai' | 'anthropic';
+
+interface KimiChatModelOptions extends ChatModelOptions {
+    /**
+     * The API key for authenticating with Kimi API.
+     */
+    apiKey: string;
+
+    /**
+     * The wire protocol to use when talking to the Kimi Code API.
+     * Kimi Code is compatible with both OpenAI and Anthropic protocols.
+     * Defaults to `'openai'`.
+     */
+    protocol?: KimiProtocol;
+
+    /**
+     * Base URL of the Kimi Code API.
+     * - For OpenAI-compatible protocol, defaults to `https://api.kimi.com/coding/v1`.
+     * - For Anthropic-compatible protocol, defaults to `https://api.kimi.com/coding`.
+     *
+     * Ignored when `apiURL` is explicitly provided.
+     */
+    baseURL?: string;
+
+    /**
+     * Full endpoint URL. When provided, this overrides `baseURL` and the
+     * default endpoint suffix inferred from the selected protocol.
+     *
+     * OpenAI example: `https://api.kimi.com/coding/v1/chat/completions`
+     * Anthropic example: `https://api.kimi.com/coding/v1/messages`
+     */
+    apiURL?: string;
+
+    /**
+     * Preset generation parameters merged into every request body.
+     */
+    presetGenParams?: Record<string, unknown>;
+
+    /**
+     * Preset headers merged into every request.
+     */
+    presetHeaders?: Record<string, unknown>;
+}
+
+const DEFAULT_OPENAI_BASE_URL = 'https://api.kimi.com/coding/v1';
+const DEFAULT_ANTHROPIC_BASE_URL = 'https://api.kimi.com/coding';
+
+/**
+ * The Kimi Code API chat model.
+ *
+ * Kimi Code exposes an API that is compatible with both the OpenAI Chat
+ * Completions protocol and the Anthropic Messages protocol. This class
+ * currently implements the OpenAI-compatible wire format, which is the
+ * recommended path. When `protocol` is set to `'anthropic'`, the default
+ * endpoint is switched accordingly but callers must ensure the request
+ * shape is honored by the target service.
+ */
+export class KimiChatModel extends ChatModelBase {
+    apiURL: string;
+    protocol: KimiProtocol;
+    protected apiKey: string;
+    protected presetGenParams: Record<string, unknown> | undefined;
+    protected presetHeaders: Record<string, unknown> | undefined;
+
+    /**
+     * Initializes a new instance of the KimiChatModel class.
+     *
+     * @param options - The Kimi chat model options.
+     * @param options.modelName - The name of the Kimi model to use, e.g. `kimi-k2-turbo-preview`.
+     * @param options.apiKey - The API key for authentication.
+     * @param options.stream - Whether to use streaming responses. Default is true.
+     * @param options.protocol - Wire protocol, `'openai'` (default) or `'anthropic'`.
+     * @param options.baseURL - Base URL, e.g. `https://api.kimi.com/coding/v1`. Ignored if `apiURL` is provided.
+     * @param options.apiURL - Full endpoint URL. Overrides `baseURL` when provided.
+     * @param options.maxRetries - Maximum number of retries for failed requests. Default is 0.
+     * @param options.fallbackModelName - Fallback model name to use if the primary model fails.
+     * @param options.presetGenParams - Preset generation parameters merged into each request.
+     * @param options.presetHeaders - Preset headers merged into each request.
+     * @param options.formatter - Optional custom formatter. Defaults to OpenAIChatFormatter.
+     */
+    constructor({
+        modelName,
+        apiKey,
+        stream = true,
+        protocol = 'openai',
+        baseURL,
+        apiURL,
+        maxRetries = 0,
+        fallbackModelName,
+        presetGenParams,
+        presetHeaders,
+        formatter,
+    }: KimiChatModelOptions) {
+        // Kimi Code is OpenAI-compatible, so reuse the OpenAI formatter by default.
+        const defaultFormatter = formatter || new OpenAIChatFormatter();
+        super({
+            modelName,
+            stream,
+            maxRetries,
+            fallbackModelName,
+            formatter: defaultFormatter,
+        } as ChatModelOptions);
+
+        this.apiKey = apiKey;
+        this.protocol = protocol;
+        this.presetGenParams = presetGenParams;
+        this.presetHeaders = presetHeaders;
+
+        if (apiURL) {
+            this.apiURL = apiURL;
+        } else {
+            const resolvedBase =
+                baseURL ??
+                (protocol === 'anthropic' ? DEFAULT_ANTHROPIC_BASE_URL : DEFAULT_OPENAI_BASE_URL);
+            const normalizedBase = resolvedBase.replace(/\/+$/, '');
+            this.apiURL =
+                protocol === 'anthropic'
+                    ? `${normalizedBase}/v1/messages`
+                    : `${normalizedBase}/chat/completions`;
+        }
+    }
+
+    /**
+     * Calls the Kimi API with the given parameters.
+     *
+     * @param modelName - The name of the model to use.
+     * @param options - The chat model options.
+     * @returns A promise that resolves to either a ChatResponse or an AsyncGenerator of ChatResponses.
+     */
+    async _callAPI(
+        modelName: string,
+        options: ChatModelRequestOptions<Record<string, unknown>>
+    ): Promise<ChatResponse | AsyncGenerator<ChatResponse, ChatResponse>> {
+        // Build request body (OpenAI-compatible schema)
+        const data = {
+            model: modelName,
+            messages: options.messages,
+            tools: this._formatToolSchemas(options.tools),
+            tool_choice: this._formatToolChoice(options.toolChoice),
+            stream: this.stream,
+            ...(this.presetGenParams ?? {}),
+        } as Record<string, unknown>;
+
+        // Build headers based on selected protocol
+        const headers: Record<string, unknown> = {
+            'Content-Type': 'application/json',
+            ...(this.protocol === 'anthropic'
+                ? {
+                      'x-api-key': this.apiKey,
+                      'anthropic-version': '2023-06-01',
+                  }
+                : {
+                      Authorization: `Bearer ${this.apiKey}`,
+                  }),
+            ...this.presetHeaders,
+        };
+
+        // Counting the time cost
+        const startTime = Date.now();
+        const response = await fetch(this.apiURL, {
+            method: 'POST',
+            headers: headers as HeadersInit,
+            body: JSON.stringify(data),
+        });
+
+        if (!response.ok) {
+            throw new Error(
+                `Kimi API request failed with status ${response.status}: ${await response.text()}`
+            );
+        }
+
+        if (this.stream) {
+            // Handle the streaming response
+            return this._parseKimiStreamedResponse(response, startTime);
+        }
+
+        // Handle the non-streaming response
+        const blocks: Array<TextBlock | ToolCallBlock | ThinkingBlock | DataBlock> = [];
+        const res = await response.json();
+        const choice = res.choices[0];
+
+        if (choice.message.reasoning_content) {
+            blocks.push({
+                id: crypto.randomUUID(),
+                type: 'thinking',
+                thinking: choice.message.reasoning_content,
+            });
+        }
+        if (choice.message.content) {
+            blocks.push({ id: crypto.randomUUID(), type: 'text', text: choice.message.content });
+        }
+        if (choice.message.tool_calls && Array.isArray(choice.message.tool_calls)) {
+            choice.message.tool_calls.forEach((toolCall: object) => {
+                if (
+                    'id' in toolCall &&
+                    'function' in toolCall &&
+                    typeof toolCall.function === 'object' &&
+                    toolCall.function &&
+                    'name' in toolCall.function &&
+                    'arguments' in toolCall.function
+                ) {
+                    const inputString = String(toolCall.function.arguments);
+                    blocks.push({
+                        type: 'tool_call',
+                        id: String(toolCall.id),
+                        name: String(toolCall.function.name),
+                        input: inputString,
+                        state: 'pending',
+                    });
+                }
+            });
+        }
+
+        const usage = res.usage
+            ? {
+                  type: 'chat_usage',
+                  inputTokens: res.usage.prompt_tokens || 0,
+                  outputTokens: res.usage.completion_tokens || 0,
+                  time: (Date.now() - startTime) / 1000,
+              }
+            : undefined;
+
+        return {
+            type: 'chat',
+            id: res.id ?? crypto.randomUUID(),
+            createdAt: res.created
+                ? new Date(res.created * 1000).toISOString()
+                : new Date().toISOString(),
+            content: blocks,
+            usage,
+        } as ChatResponse;
+    }
+
+    /**
+     * The method to format the tool choice parameter for Kimi API.
+     *
+     * @param toolChoice - The tool choice option.
+     * @returns The formatted tool choice.
+     */
+    _formatToolChoice(
+        toolChoice?: ToolChoice
+    ): 'auto' | 'none' | 'required' | Record<string, unknown> {
+        if (toolChoice) {
+            if (toolChoice === 'auto') return 'auto';
+            if (toolChoice === 'none') return 'none';
+            if (toolChoice === 'required') return 'required';
+            return {
+                type: 'function',
+                function: {
+                    name: toolChoice,
+                },
+            };
+        }
+        return 'auto';
+    }
+
+    /**
+     * Parses a streamed response from Kimi API (OpenAI-compatible SSE).
+     * An async generator that yields delta ChatResponse objects as they are received.
+     *
+     * @param response - The fetch response object.
+     * @param startTime - The start time of the request for usage calculation.
+     * @returns An async generator yielding delta ChatResponse objects, and returns the complete ChatResponse.
+     */
+    async *_parseKimiStreamedResponse(
+        response: Response,
+        startTime: number
+    ): AsyncGenerator<ChatResponse, ChatResponse> {
+        const asyncGenerator = _parseStreamedResponse<_KimiStreamChunk>(response);
+
+        let accText: string = '';
+        let accThinking: string = '';
+        // Store accumulated input strings for each tool call
+        const accToolInputs: Map<string, string> = new Map();
+        // Store tool call metadata (id, name)
+        const toolCallMeta: Map<string, { id: string; name: string }> = new Map();
+        let lastUsage: ChatUsage | undefined = undefined;
+
+        for await (const jsonObj of asyncGenerator) {
+            if (jsonObj.choices && jsonObj.choices.length > 0) {
+                const choice = jsonObj.choices[0];
+
+                // Delta data for this chunk
+                let deltaText: string = '';
+                let deltaThinking: string = '';
+                const deltaToolCalls: Map<string, ToolCallBlock> = new Map();
+
+                if (choice.delta?.content) {
+                    deltaText = choice.delta.content;
+                    accText += deltaText;
+                }
+                if (choice.delta?.reasoning_content) {
+                    deltaThinking = choice.delta.reasoning_content;
+                    accThinking += deltaThinking;
+                }
+                if (choice.delta?.tool_calls) {
+                    choice.delta.tool_calls.forEach(toolCall => {
+                        const index = toolCall.index.toString();
+
+                        // Initialize metadata if not exists
+                        if (!toolCallMeta.has(index)) {
+                            toolCallMeta.set(index, { id: '', name: '' });
+                        }
+                        if (!accToolInputs.has(index)) {
+                            accToolInputs.set(index, '');
+                        }
+
+                        // Update the tool call id
+                        if (toolCall.id) {
+                            toolCallMeta.get(index)!.id = toolCall.id;
+                        }
+                        // Update the tool call name
+                        if (toolCall.function?.name) {
+                            toolCallMeta.get(index)!.name = toolCall.function.name;
+                        }
+                        // Update the tool call input
+                        if (toolCall.function?.arguments) {
+                            const deltaArgs = toolCall.function.arguments;
+                            accToolInputs.set(index, accToolInputs.get(index)! + deltaArgs);
+
+                            // Create delta tool call with incremental input
+                            const meta = toolCallMeta.get(index)!;
+                            deltaToolCalls.set(index, {
+                                type: 'tool_call',
+                                id: meta.id,
+                                name: meta.name,
+                                input: deltaArgs,
+                                state: 'pending',
+                            });
+                        }
+                    });
+                }
+
+                // Create a delta ChatResponse object
+                const deltaBlocks = this._accDataToBlocks(deltaText, deltaThinking, deltaToolCalls);
+                lastUsage = jsonObj.usage
+                    ? {
+                          type: 'chat_usage',
+                          inputTokens: jsonObj.usage.prompt_tokens || 0,
+                          outputTokens: jsonObj.usage.completion_tokens || 0,
+                          time: (Date.now() - startTime) / 1000,
+                      }
+                    : lastUsage;
+
+                yield {
+                    type: 'chat',
+                    id: crypto.randomUUID(),
+                    createdAt: new Date().toISOString(),
+                    content: deltaBlocks,
+                    usage: lastUsage,
+                } as ChatResponse;
+            }
+        }
+        // Build final tool calls with complete JSON strings
+        const finalToolCalls: Map<string, ToolCallBlock> = new Map();
+        toolCallMeta.forEach((meta, index) => {
+            finalToolCalls.set(index, {
+                type: 'tool_call',
+                id: meta.id,
+                name: meta.name,
+                input: accToolInputs.get(index) || '{}',
+                state: 'pending',
+            });
+        });
+
+        const blocks = this._accDataToBlocks(accText, accThinking, finalToolCalls);
+        return {
+            type: 'chat',
+            id: crypto.randomUUID(),
+            createdAt: new Date().toISOString(),
+            content: blocks,
+            usage: lastUsage,
+        } as ChatResponse;
+    }
+
+    /**
+     * Convert accumulated data into content blocks.
+     *
+     * @param text - The text response from the LLM API
+     * @param thinking - The thinking response
+     * @param toolCalls - The tool calls
+     * @returns An array of blocks
+     */
+    _accDataToBlocks(
+        text: string,
+        thinking: string,
+        toolCalls: Map<string, ToolCallBlock>
+    ): (TextBlock | ThinkingBlock | ToolCallBlock)[] {
+        const blocks: (TextBlock | ThinkingBlock | ToolCallBlock)[] = [];
+        if (thinking) {
+            blocks.push({ id: crypto.randomUUID(), type: 'thinking', thinking: thinking });
+        }
+        if (text) {
+            blocks.push({ id: crypto.randomUUID(), type: 'text', text: text });
+        }
+        if (toolCalls.size > 0) {
+            toolCalls.forEach(value => {
+                blocks.push(value);
+            });
+        }
+
+        return blocks;
+    }
+
+    /**
+     * Format the tool schemas to the expected Kimi API format.
+     * Kimi is OpenAI-compatible so the schemas can be passed through unchanged.
+     * @param tools
+     * @returns The formatted tool schemas.
+     */
+    _formatToolSchemas(tools: ToolSchema[] | undefined): ToolSchema[] {
+        return tools || [];
+    }
+}


### PR DESCRIPTION
## Linked Issues

- Closes #8

## Description

### Background
Kimi Code 提供了兼容 OpenAI Chat Completions 的 API，本 PR 新增 `KimiChatModel`，让用户可以直接使用 Kimi 系列模型。

### Changes
- 新增 `KimiChatModel`：`packages/agentscope/src/model/kimi-model.ts`
  - 支持 OpenAI 兼容协议（默认，推荐）
  - 通过 `baseURL` / `apiURL` 灵活配置端点
  - 支持流式与非流式响应
  - 支持 tool calling API 与 tool_choice
  - 支持 `reasoning_content` 思考块
- 新增单元测试：`packages/agentscope/src/model/kimi-model.test.ts`
  - 覆盖 `call`（流式/非流式工具调用响应）
  - 覆盖 `_formatToolChoice`（auto/none/required/named/undefined）
  - 覆盖 `_formatToolSchemas`
  - 覆盖端点解析与鉴权头
- 在 `packages/agentscope/src/model/index.ts` 中导出 `KimiChatModel` 与 `KimiProtocol` 类型
- 在 `.gitignore` 中排除本地冒烟测试目录

### How to Test
\`\`\`bash
pnpm --filter @agentscope-ai/agentscope test -- kimi-model
\`\`\`
<img width="567" height="314" alt="image" src="https://github.com/user-attachments/assets/92266f30-4da8-4a29-96b4-93873e774903" />

<img width="664" height="699" alt="image" src="https://github.com/user-attachments/assets/9b9458d6-2ac5-409b-98d7-51ff01642552" />

## Checklist

- [x] This PR is linked to a related issue (see above)
- [x] Code has been formatted with `pnpm format`
- [x] Related documentation has been updated
- [x] All tests are passing (`pnpm test`)
- [x] Code is ready for review