### PR TITLE
feat(model): add Grok chat model and unit tests

### DIFF
--- a/packages/agentscope/src/model/grok-model.test.ts
+++ b/packages/agentscope/src/model/grok-model.test.ts
@@ -1,0 +1,605 @@
+import { GrokChatModel } from './grok-model';
+import { ChatResponse } from './response';
+import { createMsg } from '../message';
+
+// Mock global fetch for all tests
+global.fetch = jest.fn();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal tool schema used across tests. */
+const weatherToolSchema = [
+    {
+        type: 'function' as const,
+        function: {
+            name: 'get_current_weather',
+            description: 'Get the current weather in a given location',
+            parameters: {
+                type: 'object' as const,
+                properties: {
+                    location: {
+                        type: 'string',
+                        description: 'The city and state, e.g. San Francisco, CA',
+                    },
+                },
+                required: ['location'],
+            },
+        },
+    },
+];
+
+/**
+ * Build a ReadableStream from an array of SSE string chunks.
+ * @param chunks
+ */
+function buildReadableStream(chunks: string[]): ReadableStream {
+    return new ReadableStream({
+        start(controller) {
+            chunks.forEach(chunk => controller.enqueue(new TextEncoder().encode(chunk)));
+            controller.close();
+        },
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('GrokChatModel', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 1. Streaming – plain text response
+    // ──────────────────────────────────────────────────────────────────────────
+    test('streams plain-text response and returns complete ChatResponse', async () => {
+        const mockChunks = [
+            'data: {"id":"chatcmpl-g1","created":1739301120,"choices":[{"index":0,"delta":{"content":"Ah,","role":"assistant"}}],"usage":{"prompt_tokens":41,"completion_tokens":1,"total_tokens":42}}\n\n',
+            'data: {"id":"chatcmpl-g1","created":1739301120,"choices":[{"index":0,"delta":{"content":" the answer is 42.","role":"assistant"}}],"usage":{"prompt_tokens":41,"completion_tokens":5,"total_tokens":46}}\n\n',
+            'data: {"id":"chatcmpl-g1","created":1739301120,"choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":41,"completion_tokens":6,"total_tokens":47}}\n\n',
+            'data: [DONE]\n\n',
+        ];
+
+        (global.fetch as jest.Mock).mockResolvedValue({
+            ok: true,
+            body: buildReadableStream(mockChunks),
+        });
+
+        const model = new GrokChatModel({
+            modelName: 'grok-3-latest',
+            apiKey: 'test-xai-key',
+        });
+
+        const res = await model.call({
+            messages: [
+                createMsg({
+                    name: 'user',
+                    role: 'user',
+                    content: [
+                        {
+                            id: crypto.randomUUID(),
+                            type: 'text',
+                            text: 'What is the meaning of life?',
+                        },
+                    ],
+                }),
+            ],
+        });
+
+        const generator = res as AsyncGenerator<ChatResponse, ChatResponse>;
+        const yieldedChunks: ChatResponse[] = [];
+        let completeResponse: ChatResponse | undefined;
+
+        while (true) {
+            const result = await generator.next();
+            if (result.done) {
+                completeResponse = result.value;
+                break;
+            }
+            yieldedChunks.push(result.value);
+        }
+
+        // Should have received at least 1 delta chunk
+        expect(yieldedChunks.length).toBeGreaterThan(0);
+
+        // Final response: single text block with accumulated content
+        expect(completeResponse).toBeDefined();
+        expect(completeResponse!.content.length).toBe(1);
+
+        const textBlock = completeResponse!.content[0];
+        expect(textBlock.type).toBe('text');
+        if (textBlock.type === 'text') {
+            expect(textBlock.text).toBe('Ah, the answer is 42.');
+        }
+
+        // Usage present
+        expect(completeResponse!.usage).toBeDefined();
+        expect(completeResponse!.usage?.inputTokens).toBe(41);
+    }, 10000);
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 2. Streaming – reasoning model (grok-3-mini-*) with thinking + text
+    // ──────────────────────────────────────────────────────────────────────────
+    test('streams reasoning_content (thinking) and text for grok-3-mini models', async () => {
+        const mockChunks = [
+            'data: {"id":"chatcmpl-g2","created":1739301200,"choices":[{"index":0,"delta":{"reasoning_content":"Let me think...","role":"assistant"}}]}\n\n',
+            'data: {"id":"chatcmpl-g2","created":1739301200,"choices":[{"index":0,"delta":{"reasoning_content":" 101 * 3 = 303.","role":"assistant"}}]}\n\n',
+            'data: {"id":"chatcmpl-g2","created":1739301200,"choices":[{"index":0,"delta":{"content":"The answer is 303.","role":"assistant"}}],"usage":{"prompt_tokens":14,"completion_tokens":10,"total_tokens":24}}\n\n',
+            'data: {"id":"chatcmpl-g2","created":1739301200,"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
+            'data: [DONE]\n\n',
+        ];
+
+        (global.fetch as jest.Mock).mockResolvedValue({
+            ok: true,
+            body: buildReadableStream(mockChunks),
+        });
+
+        const model = new GrokChatModel({
+            modelName: 'grok-3-mini-latest',
+            apiKey: 'test-xai-key',
+            reasoningConfig: { reasoningEffort: 'high' },
+        });
+
+        const res = await model.call({
+            messages: [
+                createMsg({
+                    name: 'user',
+                    role: 'user',
+                    content: [{ id: crypto.randomUUID(), type: 'text', text: 'What is 101*3?' }],
+                }),
+            ],
+        });
+
+        const generator = res as AsyncGenerator<ChatResponse, ChatResponse>;
+        let completeResponse: ChatResponse | undefined;
+
+        while (true) {
+            const result = await generator.next();
+            if (result.done) {
+                completeResponse = result.value;
+                break;
+            }
+        }
+
+        // Final response should have thinking + text blocks
+        expect(completeResponse!.content.length).toBe(2);
+
+        const thinkingBlock = completeResponse!.content.find(b => b.type === 'thinking');
+        expect(thinkingBlock).toBeDefined();
+        expect(thinkingBlock).toMatchObject({
+            type: 'thinking',
+            thinking: 'Let me think... 101 * 3 = 303.',
+        });
+
+        const textBlock = completeResponse!.content.find(b => b.type === 'text');
+        expect(textBlock).toBeDefined();
+        expect(textBlock).toMatchObject({
+            type: 'text',
+            text: 'The answer is 303.',
+        });
+    }, 10000);
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 3. Streaming – tool call accumulation
+    // ──────────────────────────────────────────────────────────────────────────
+    test('streams and accumulates tool call arguments correctly', async () => {
+        const mockChunks = [
+            'data: {"id":"chatcmpl-g3","created":1739301300,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call-abc","function":{"name":"get_current_weather","arguments":"{\\"location\\""}}],"role":"assistant"}}]}\n\n',
+            'data: {"id":"chatcmpl-g3","created":1739301300,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":":\\"London\\"}"}]}}]}\n\n',
+            'data: {"id":"chatcmpl-g3","created":1739301300,"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":80,"completion_tokens":25,"total_tokens":105}}\n\n',
+            'data: [DONE]\n\n',
+        ];
+
+        (global.fetch as jest.Mock).mockResolvedValue({
+            ok: true,
+            body: buildReadableStream(mockChunks),
+        });
+
+        const model = new GrokChatModel({
+            modelName: 'grok-3-latest',
+            apiKey: 'test-xai-key',
+        });
+
+        const res = await model.call({
+            messages: [
+                createMsg({
+                    name: 'user',
+                    role: 'user',
+                    content: [{ id: crypto.randomUUID(), type: 'text', text: 'London weather?' }],
+                }),
+            ],
+            tools: weatherToolSchema,
+        });
+
+        const generator = res as AsyncGenerator<ChatResponse, ChatResponse>;
+        let completeResponse: ChatResponse | undefined;
+
+        while (true) {
+            const result = await generator.next();
+            if (result.done) {
+                completeResponse = result.value;
+                break;
+            }
+        }
+
+        const toolCallBlock = completeResponse!.content.find(b => b.type === 'tool_call');
+        expect(toolCallBlock).toBeDefined();
+        expect(toolCallBlock).toMatchObject({
+            type: 'tool_call',
+            id: 'call-abc',
+            name: 'get_current_weather',
+            input: '{"location":"London"}',
+            state: 'pending',
+        });
+
+        expect(completeResponse!.usage?.inputTokens).toBe(80);
+        expect(completeResponse!.usage?.outputTokens).toBe(25);
+    }, 10000);
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 4. Non-streaming – plain text
+    // ──────────────────────────────────────────────────────────────────────────
+    test('returns complete ChatResponse in non-streaming mode (plain text)', async () => {
+        const mockResponse = {
+            id: 'chatcmpl-g4',
+            object: 'chat.completion',
+            created: 1739301120,
+            model: 'grok-3-latest',
+            choices: [
+                {
+                    index: 0,
+                    message: {
+                        role: 'assistant',
+                        content: 'The meaning of life, the universe, and everything is 42.',
+                        refusal: null,
+                    },
+                    finish_reason: 'stop',
+                },
+            ],
+            usage: {
+                prompt_tokens: 41,
+                completion_tokens: 104,
+                total_tokens: 145,
+            },
+            system_fingerprint: 'fp_84ff176447',
+        };
+
+        (global.fetch as jest.Mock).mockResolvedValue({
+            ok: true,
+            json: async () => mockResponse,
+        });
+
+        const model = new GrokChatModel({
+            modelName: 'grok-3-latest',
+            apiKey: 'test-xai-key',
+            stream: false,
+        });
+
+        const res = await model.call({
+            messages: [
+                createMsg({
+                    name: 'user',
+                    role: 'user',
+                    content: [
+                        {
+                            id: crypto.randomUUID(),
+                            type: 'text',
+                            text: 'What is the meaning of life?',
+                        },
+                    ],
+                }),
+            ],
+        });
+
+        const response = res as ChatResponse;
+        expect(response.content.length).toBe(1);
+        expect(response.content[0].type).toBe('text');
+        if (response.content[0].type === 'text') {
+            expect(response.content[0].text).toBe(
+                'The meaning of life, the universe, and everything is 42.'
+            );
+        }
+
+        expect(response.usage?.inputTokens).toBe(41);
+        expect(response.usage?.outputTokens).toBe(104);
+        // id preserved from API response
+        expect(response.id).toBe('chatcmpl-g4');
+    }, 10000);
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 5. Non-streaming – reasoning model with tool call
+    // ──────────────────────────────────────────────────────────────────────────
+    test('returns thinking block + tool call in non-streaming mode', async () => {
+        const mockResponse = {
+            id: 'chatcmpl-g5',
+            object: 'chat.completion',
+            created: 1739301200,
+            model: 'grok-3-mini-latest',
+            choices: [
+                {
+                    index: 0,
+                    message: {
+                        role: 'assistant',
+                        reasoning_content:
+                            'User wants London weather. I should call the weather tool.',
+                        content: null,
+                        tool_calls: [
+                            {
+                                id: 'call-xyz',
+                                type: 'function',
+                                function: {
+                                    name: 'get_current_weather',
+                                    arguments: '{"location":"London"}',
+                                },
+                            },
+                        ],
+                    },
+                    finish_reason: 'tool_calls',
+                },
+            ],
+            usage: {
+                prompt_tokens: 80,
+                completion_tokens: 30,
+                total_tokens: 110,
+            },
+        };
+
+        (global.fetch as jest.Mock).mockResolvedValue({
+            ok: true,
+            json: async () => mockResponse,
+        });
+
+        const model = new GrokChatModel({
+            modelName: 'grok-3-mini-latest',
+            apiKey: 'test-xai-key',
+            stream: false,
+            reasoningConfig: { reasoningEffort: 'high' },
+        });
+
+        const res = await model.call({
+            messages: [
+                createMsg({
+                    name: 'user',
+                    role: 'user',
+                    content: [{ id: crypto.randomUUID(), type: 'text', text: 'London weather?' }],
+                }),
+            ],
+            tools: weatherToolSchema,
+        });
+
+        const response = res as ChatResponse;
+        expect(response.content.length).toBe(2);
+
+        const thinkingBlock = response.content.find(b => b.type === 'thinking');
+        expect(thinkingBlock).toMatchObject({
+            type: 'thinking',
+            thinking: 'User wants London weather. I should call the weather tool.',
+        });
+
+        const toolCallBlock = response.content.find(b => b.type === 'tool_call');
+        expect(toolCallBlock).toMatchObject({
+            type: 'tool_call',
+            id: 'call-xyz',
+            name: 'get_current_weather',
+            input: '{"location":"London"}',
+            state: 'pending',
+        });
+
+        expect(response.usage?.inputTokens).toBe(80);
+        expect(response.usage?.outputTokens).toBe(30);
+    }, 10000);
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 6. Error handling – non-2xx API response
+    // ──────────────────────────────────────────────────────────────────────────
+    test('throws an error when the API returns a non-ok status', async () => {
+        (global.fetch as jest.Mock).mockResolvedValue({
+            ok: false,
+            status: 401,
+            text: async () => 'Unauthorized',
+        });
+
+        const model = new GrokChatModel({
+            modelName: 'grok-3-latest',
+            apiKey: 'invalid-key',
+            stream: false,
+        });
+
+        await expect(
+            model.call({
+                messages: [
+                    createMsg({
+                        name: 'user',
+                        role: 'user',
+                        content: [{ id: crypto.randomUUID(), type: 'text', text: 'Hello' }],
+                    }),
+                ],
+            })
+        ).rejects.toThrow('Grok API request failed with status 401: Unauthorized');
+    });
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 7. _formatToolChoice
+    // ──────────────────────────────────────────────────────────────────────────
+    test('_formatToolChoice returns correct values for standard options', () => {
+        const model = new GrokChatModel({
+            modelName: 'grok-3-latest',
+            apiKey: 'test-key',
+        });
+
+        expect(model._formatToolChoice('auto')).toBe('auto');
+        expect(model._formatToolChoice('none')).toBe('none');
+        expect(model._formatToolChoice('required')).toBe('required');
+        expect(model._formatToolChoice('get_current_weather')).toEqual({
+            type: 'function',
+            function: { name: 'get_current_weather' },
+        });
+        // Undefined defaults to 'auto'
+        expect(model._formatToolChoice(undefined)).toBe('auto');
+    });
+
+    test('_formatToolChoice falls back to "auto" for specific function names when reasoningConfig is set', () => {
+        const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+        const model = new GrokChatModel({
+            modelName: 'grok-3-mini-latest',
+            apiKey: 'test-key',
+            reasoningConfig: { reasoningEffort: 'high' },
+        });
+
+        // Specific function name should be downgraded to 'auto' for reasoning models
+        expect(model._formatToolChoice('get_current_weather')).toBe('auto');
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Falling back to 'auto'"));
+
+        // Standard options still pass through
+        expect(model._formatToolChoice('none')).toBe('none');
+        expect(model._formatToolChoice('auto')).toBe('auto');
+
+        consoleSpy.mockRestore();
+    });
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 8. _formatToolSchemas
+    // ──────────────────────────────────────────────────────────────────────────
+    test('_formatToolSchemas returns schemas unchanged and empty array for undefined', () => {
+        const model = new GrokChatModel({
+            modelName: 'grok-3-latest',
+            apiKey: 'test-key',
+        });
+
+        expect(model._formatToolSchemas(weatherToolSchema)).toEqual(weatherToolSchema);
+        expect(model._formatToolSchemas(undefined)).toEqual([]);
+    });
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 9. Request body includes reasoning_effort when reasoningConfig is set
+    // ──────────────────────────────────────────────────────────────────────────
+    test('includes reasoning_effort in request body when reasoningConfig is provided', async () => {
+        (global.fetch as jest.Mock).mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                id: 'chatcmpl-g9',
+                created: 1739301200,
+                choices: [
+                    {
+                        index: 0,
+                        message: { role: 'assistant', content: 'Result: 303.' },
+                        finish_reason: 'stop',
+                    },
+                ],
+                usage: { prompt_tokens: 14, completion_tokens: 5 },
+            }),
+        });
+
+        const model = new GrokChatModel({
+            modelName: 'grok-3-mini-latest',
+            apiKey: 'test-key',
+            stream: false,
+            reasoningConfig: { reasoningEffort: 'high' },
+        });
+
+        await model.call({
+            messages: [
+                createMsg({
+                    name: 'user',
+                    role: 'user',
+                    content: [{ id: crypto.randomUUID(), type: 'text', text: 'What is 101*3?' }],
+                }),
+            ],
+        });
+
+        const requestBody = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+        expect(requestBody.reasoning_effort).toBe('high');
+        expect(requestBody.model).toBe('grok-3-mini-latest');
+    });
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 10. presetGenParams are merged into the request body
+    // ──────────────────────────────────────────────────────────────────────────
+    test('merges presetGenParams into every request body', async () => {
+        (global.fetch as jest.Mock).mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                id: 'chatcmpl-g10',
+                created: 1739301200,
+                choices: [
+                    {
+                        index: 0,
+                        message: { role: 'assistant', content: 'Hello' },
+                        finish_reason: 'stop',
+                    },
+                ],
+                usage: { prompt_tokens: 5, completion_tokens: 2 },
+            }),
+        });
+
+        const model = new GrokChatModel({
+            modelName: 'grok-3-latest',
+            apiKey: 'test-key',
+            stream: false,
+            presetGenParams: { temperature: 0, max_tokens: 512 },
+        });
+
+        await model.call({
+            messages: [
+                createMsg({
+                    name: 'user',
+                    role: 'user',
+                    content: [{ id: crypto.randomUUID(), type: 'text', text: 'Hi' }],
+                }),
+            ],
+        });
+
+        const requestBody = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+        expect(requestBody.temperature).toBe(0);
+        expect(requestBody.max_tokens).toBe(512);
+    });
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 11. API URL is set to the xAI endpoint
+    // ──────────────────────────────────────────────────────────────────────────
+    test('sends requests to the xAI API endpoint', async () => {
+        (global.fetch as jest.Mock).mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                id: 'chatcmpl-g11',
+                created: 1739301200,
+                choices: [
+                    {
+                        index: 0,
+                        message: { role: 'assistant', content: 'Ok' },
+                        finish_reason: 'stop',
+                    },
+                ],
+                usage: { prompt_tokens: 5, completion_tokens: 1 },
+            }),
+        });
+
+        const model = new GrokChatModel({
+            modelName: 'grok-3-latest',
+            apiKey: 'test-key',
+            stream: false,
+        });
+
+        await model.call({
+            messages: [
+                createMsg({
+                    name: 'user',
+                    role: 'user',
+                    content: [{ id: crypto.randomUUID(), type: 'text', text: 'Hi' }],
+                }),
+            ],
+        });
+
+        expect((global.fetch as jest.Mock).mock.calls[0][0]).toBe(
+            'https://api.x.ai/v1/chat/completions'
+        );
+
+        const requestHeaders = (global.fetch as jest.Mock).mock.calls[0][1].headers;
+        expect(requestHeaders.Authorization).toBe('Bearer test-key');
+        expect(requestHeaders['Content-Type']).toBe('application/json');
+    });
+});

--- a/packages/agentscope/src/model/grok-model.ts
+++ b/packages/agentscope/src/model/grok-model.ts
@@ -1,0 +1,480 @@
+import { ChatModelBase, ChatModelOptions, ChatModelRequestOptions } from './base';
+import { ChatResponse } from './response';
+import { DataBlock, TextBlock, ThinkingBlock, ToolCallBlock } from '../message';
+import { ToolChoice, ToolSchema } from '../type';
+import { ChatUsage } from './usage';
+import { _parseStreamedResponse } from '../_utils';
+import { OpenAIChatFormatter } from '../formatter';
+
+/**
+ * The shape of a single SSE chunk returned by the xAI Grok streaming API.
+ * The API is OpenAI-compatible, so the shape mirrors OpenAI's chat.completion.chunk format.
+ */
+interface _GrokStreamChunk {
+    id?: string;
+    created?: number;
+    choices?: {
+        index: number;
+        delta?: {
+            /** Plain-text response delta */
+            content?: string;
+            /** Chain-of-thought / reasoning delta (only present for grok-3-mini-* models) */
+            reasoning_content?: string;
+            tool_calls?: {
+                index: number;
+                id?: string;
+                function?: {
+                    name?: string;
+                    arguments?: string;
+                };
+            }[];
+        };
+        finish_reason?: string | null;
+    }[];
+    usage?: {
+        prompt_tokens?: number;
+        completion_tokens?: number;
+    };
+}
+
+/**
+ * Reasoning configuration for Grok mini models.
+ * Only applicable to `grok-3-mini-*` and `grok-3-mini-fast-*` models.
+ */
+export type GrokReasoningEffort = 'low' | 'high';
+
+interface GrokReasoningConfig {
+    /**
+     * Controls how hard the model thinks before responding.
+     * - `low`: Minimal thinking, fewer tokens, faster responses.
+     * - `high`: Maximum thinking, more tokens, more accurate answers.
+     *
+     * Only supported by `grok-3-mini-*` models; omit for `grok-3-*` or `grok-3-fast-*`.
+     */
+    reasoningEffort: GrokReasoningEffort;
+}
+
+export interface GrokChatModelOptions extends ChatModelOptions {
+    /**
+     * The API key for authenticating with the xAI API.
+     */
+    apiKey: string;
+
+    /**
+     * Reasoning configuration.  Providing this enables chain-of-thought output via
+     * `reasoning_content` in the response.  Only supported by `grok-3-mini-*` models.
+     */
+    reasoningConfig?: GrokReasoningConfig;
+
+    /**
+     * Preset generation parameters merged into every request body.
+     * Useful for setting `temperature`, `max_tokens`, etc.
+     */
+    presetGenParams?: Record<string, unknown>;
+
+    /**
+     * Preset headers merged into every request.
+     */
+    presetHeaders?: Record<string, unknown>;
+}
+
+/**
+ * A chat model implementation for xAI's Grok API.
+ *
+ * The xAI API is OpenAI-compatible, so this class uses `fetch` directly
+ * against `https://api.x.ai/v1/chat/completions`.
+ *
+ * Supported features:
+ * - Streaming (SSE) and non-streaming responses
+ * - Tool / function calling
+ * - Chain-of-thought reasoning via `reasoning_effort` (grok-3-mini-* only)
+ * - Preset generation parameters and headers
+ *
+ * @example
+ * ```typescript
+ * const model = new GrokChatModel({
+ *     apiKey: process.env.XAI_API_KEY!,
+ *     modelName: 'grok-3-latest',
+ * });
+ * const res = await model.call({ messages });
+ * ```
+ */
+export class GrokChatModel extends ChatModelBase {
+    /** The xAI chat completions endpoint. */
+    apiURL: string;
+
+    protected apiKey: string;
+    protected reasoningConfig: GrokReasoningConfig | undefined;
+    protected presetGenParams: Record<string, unknown> | undefined;
+    protected presetHeaders: Record<string, unknown> | undefined;
+
+    /**
+     * Initializes a new instance of GrokChatModel.
+     *
+     * @param options - Configuration options.
+     * @param options.modelName - e.g. `'grok-3-latest'`, `'grok-3-mini-latest'`.
+     * @param options.apiKey - xAI API key.
+     * @param options.stream - Whether to use streaming responses. Defaults to `true`.
+     * @param options.maxRetries - Number of retry attempts on transient failures. Defaults to `0`.
+     * @param options.fallbackModelName - Alternative model to try after exhausting retries.
+     * @param options.reasoningConfig - Enables chain-of-thought for `grok-3-mini-*` models.
+     * @param options.presetGenParams - Extra body parameters merged into every request.
+     * @param options.presetHeaders - Extra headers merged into every request.
+     * @param options.formatter - Custom message formatter. Defaults to `OpenAIChatFormatter`.
+     */
+    constructor({
+        modelName,
+        apiKey,
+        stream = true,
+        maxRetries = 0,
+        fallbackModelName,
+        reasoningConfig,
+        presetGenParams,
+        presetHeaders,
+        formatter,
+    }: GrokChatModelOptions) {
+        // xAI's message format is OpenAI-compatible
+        const defaultFormatter = formatter || new OpenAIChatFormatter();
+        super({
+            modelName,
+            stream,
+            maxRetries,
+            fallbackModelName,
+            formatter: defaultFormatter,
+        } as ChatModelOptions);
+
+        this.apiKey = apiKey;
+        this.reasoningConfig = reasoningConfig;
+        this.presetGenParams = presetGenParams;
+        this.presetHeaders = presetHeaders;
+        this.apiURL = 'https://api.x.ai/v1/chat/completions';
+    }
+
+    /**
+     * Executes a chat completion request against the xAI API.
+     *
+     * @param modelName - The Grok model identifier.
+     * @param options - Formatted request options produced by the base `call()` method.
+     * @returns Either a complete `ChatResponse` (non-streaming) or an async generator
+     *   that yields delta `ChatResponse` objects and returns the final complete response.
+     */
+    async _callAPI(
+        modelName: string,
+        options: ChatModelRequestOptions<Record<string, unknown>>
+    ): Promise<ChatResponse | AsyncGenerator<ChatResponse, ChatResponse>> {
+        // Build the request body
+        const data: Record<string, unknown> = {
+            model: modelName,
+            messages: options.messages,
+            stream: this.stream,
+            ...(this.presetGenParams ?? {}),
+        };
+
+        // Attach tool schemas when provided
+        const formattedTools = this._formatToolSchemas(options.tools);
+        if (formattedTools.length > 0) {
+            data.tools = formattedTools;
+            data.tool_choice = this._formatToolChoice(options.toolChoice);
+        }
+
+        // Attach reasoning_effort for grok-3-mini-* models only
+        if (this.reasoningConfig) {
+            data.reasoning_effort = this.reasoningConfig.reasoningEffort;
+        }
+
+        const headers: Record<string, unknown> = {
+            Authorization: `Bearer ${this.apiKey}`,
+            'Content-Type': 'application/json',
+            ...this.presetHeaders,
+        };
+
+        const startTime = Date.now();
+        const response = await fetch(this.apiURL, {
+            method: 'POST',
+            headers: headers as HeadersInit,
+            body: JSON.stringify(data),
+        });
+
+        if (!response.ok) {
+            throw new Error(
+                `Grok API request failed with status ${response.status}: ${await response.text()}`
+            );
+        }
+
+        if (this.stream) {
+            return this._parseGrokStreamedResponse(response, startTime);
+        }
+
+        // ── Non-streaming path ──────────────────────────────────────────────────
+        const blocks: Array<TextBlock | ToolCallBlock | ThinkingBlock | DataBlock> = [];
+        const res = await response.json();
+        const choice = res.choices[0];
+
+        // Reasoning trace (only present for grok-3-mini-* models)
+        if (choice.message.reasoning_content) {
+            blocks.push({
+                id: crypto.randomUUID(),
+                type: 'thinking',
+                thinking: choice.message.reasoning_content,
+            });
+        }
+
+        // Plain-text reply
+        if (choice.message.content) {
+            blocks.push({ id: crypto.randomUUID(), type: 'text', text: choice.message.content });
+        }
+
+        // Tool calls
+        if (choice.message.tool_calls && Array.isArray(choice.message.tool_calls)) {
+            choice.message.tool_calls.forEach((toolCall: object) => {
+                if (
+                    'id' in toolCall &&
+                    'function' in toolCall &&
+                    typeof toolCall.function === 'object' &&
+                    toolCall.function &&
+                    'name' in toolCall.function &&
+                    'arguments' in toolCall.function
+                ) {
+                    blocks.push({
+                        type: 'tool_call',
+                        id: String(toolCall.id),
+                        name: String(toolCall.function.name),
+                        input: String(toolCall.function.arguments),
+                        state: 'pending',
+                    });
+                }
+            });
+        }
+
+        const usage = res.usage
+            ? {
+                  type: 'chat_usage' as const,
+                  inputTokens: res.usage.prompt_tokens || 0,
+                  outputTokens: res.usage.completion_tokens || 0,
+                  time: (Date.now() - startTime) / 1000,
+              }
+            : undefined;
+
+        return {
+            type: 'chat',
+            id: res.id || crypto.randomUUID(),
+            createdAt: res.created
+                ? new Date(res.created * 1000).toISOString()
+                : new Date().toISOString(),
+            content: blocks,
+            usage,
+        } as ChatResponse;
+    }
+
+    /**
+     * Formats the AgentScope `ToolChoice` type into the xAI API format.
+     *
+     * xAI accepts: `'auto'`, `'none'`, `'required'`, or a specific function descriptor.
+     * Reasoning models (grok-3-mini-*) do NOT support forced tool choice; if
+     * `reasoningConfig` is set and a specific function name is requested, `'auto'`
+     * is used instead.
+     *
+     * @param toolChoice - The AgentScope tool-choice option.
+     * @returns The formatted value ready to be sent to the API.
+     */
+    _formatToolChoice(
+        toolChoice?: ToolChoice
+    ): 'auto' | 'none' | 'required' | Record<string, unknown> {
+        if (toolChoice) {
+            if (toolChoice === 'auto') return 'auto';
+            if (toolChoice === 'none') return 'none';
+
+            // Reasoning models do not support explicit function name forcing
+            if (this.reasoningConfig) {
+                console.log(
+                    `Grok reasoning models do not support explicit tool choice '${toolChoice}'. ` +
+                        `Falling back to 'auto'.`
+                );
+                return 'auto';
+            }
+
+            if (toolChoice === 'required') return 'required';
+
+            return {
+                type: 'function',
+                function: { name: toolChoice },
+            };
+        }
+        return 'auto';
+    }
+
+    /**
+     * Passes tool schemas through unchanged; xAI accepts the standard OpenAI
+     * function-calling schema format without modification.
+     *
+     * @param tools - Array of tool schemas (or undefined).
+     * @returns The same array, or an empty array if undefined.
+     */
+    _formatToolSchemas(tools: ToolSchema[] | undefined): ToolSchema[] {
+        return tools || [];
+    }
+
+    /**
+     * Parses a server-sent-event stream from the xAI API, yielding delta
+     * `ChatResponse` objects as chunks arrive and returning the final
+     * fully-accumulated response when the stream completes.
+     *
+     * @param response - The raw `fetch` Response with a readable body.
+     * @param startTime - Timestamp (ms) when the request was dispatched.
+     * @returns An async generator that yields deltas and returns the complete response.
+     */
+    async *_parseGrokStreamedResponse(
+        response: Response,
+        startTime: number
+    ): AsyncGenerator<ChatResponse, ChatResponse> {
+        const asyncGenerator = _parseStreamedResponse<_GrokStreamChunk>(response);
+
+        let accText = '';
+        let accThinking = '';
+        // Accumulated JSON argument strings keyed by tool-call index
+        const accToolInputs: Map<string, string> = new Map();
+        // Tool-call metadata (id, name) keyed by index
+        const toolCallMeta: Map<string, { id: string; name: string }> = new Map();
+        let lastUsage: ChatUsage | undefined = undefined;
+        let responseId = '';
+        let createdTimestamp = 0;
+
+        for await (const jsonObj of asyncGenerator) {
+            if (!responseId && jsonObj.id) {
+                responseId = jsonObj.id;
+            }
+            if (!createdTimestamp && jsonObj.created) {
+                createdTimestamp = jsonObj.created;
+            }
+
+            if (jsonObj.choices && jsonObj.choices.length > 0) {
+                const choice = jsonObj.choices[0];
+
+                let deltaText = '';
+                let deltaThinking = '';
+                const deltaToolCalls: Map<string, ToolCallBlock> = new Map();
+
+                // Plain-text delta
+                if (choice.delta?.content) {
+                    deltaText = choice.delta.content;
+                    accText += deltaText;
+                }
+
+                // Reasoning / thinking delta (grok-3-mini-* only)
+                if (choice.delta?.reasoning_content) {
+                    deltaThinking = choice.delta.reasoning_content;
+                    accThinking += deltaThinking;
+                }
+
+                // Tool-call argument deltas
+                if (choice.delta?.tool_calls) {
+                    choice.delta.tool_calls.forEach(toolCall => {
+                        const index = toolCall.index.toString();
+
+                        if (!toolCallMeta.has(index)) {
+                            toolCallMeta.set(index, { id: '', name: '' });
+                        }
+                        if (!accToolInputs.has(index)) {
+                            accToolInputs.set(index, '');
+                        }
+
+                        if (toolCall.id) {
+                            toolCallMeta.get(index)!.id = toolCall.id;
+                        }
+                        if (toolCall.function?.name) {
+                            toolCallMeta.get(index)!.name = toolCall.function.name;
+                        }
+                        if (toolCall.function?.arguments) {
+                            const deltaArgs = toolCall.function.arguments;
+                            accToolInputs.set(index, accToolInputs.get(index)! + deltaArgs);
+
+                            const meta = toolCallMeta.get(index)!;
+                            deltaToolCalls.set(index, {
+                                type: 'tool_call',
+                                id: meta.id,
+                                name: meta.name,
+                                input: deltaArgs,
+                                state: 'pending',
+                            });
+                        }
+                    });
+                }
+
+                // Capture usage (typically only present in the final chunk)
+                if (jsonObj.usage) {
+                    lastUsage = {
+                        type: 'chat_usage',
+                        inputTokens: jsonObj.usage.prompt_tokens || 0,
+                        outputTokens: jsonObj.usage.completion_tokens || 0,
+                        time: (Date.now() - startTime) / 1000,
+                    };
+                }
+
+                const deltaBlocks = this._accDataToBlocks(deltaText, deltaThinking, deltaToolCalls);
+
+                yield {
+                    type: 'chat',
+                    id: responseId || crypto.randomUUID(),
+                    createdAt: createdTimestamp
+                        ? new Date(createdTimestamp * 1000).toISOString()
+                        : new Date().toISOString(),
+                    content: deltaBlocks,
+                    usage: lastUsage,
+                } as ChatResponse;
+            }
+        }
+
+        // Build the final complete response with fully-accumulated data
+        const finalToolCalls: Map<string, ToolCallBlock> = new Map();
+        toolCallMeta.forEach((meta, index) => {
+            finalToolCalls.set(index, {
+                type: 'tool_call',
+                id: meta.id,
+                name: meta.name,
+                input: accToolInputs.get(index) || '{}',
+                state: 'pending',
+            });
+        });
+
+        const blocks = this._accDataToBlocks(accText, accThinking, finalToolCalls);
+        return {
+            type: 'chat',
+            id: responseId || crypto.randomUUID(),
+            createdAt: createdTimestamp
+                ? new Date(createdTimestamp * 1000).toISOString()
+                : new Date().toISOString(),
+            content: blocks,
+            usage: lastUsage,
+        } as ChatResponse;
+    }
+
+    /**
+     * Assembles an array of content blocks from accumulated text, thinking, and tool-call data.
+     *
+     * Order: thinking -> text -> tool_calls (mirrors DeepSeek convention).
+     *
+     * @param text - The accumulated (or delta) plain-text reply.
+     * @param thinking - The accumulated (or delta) reasoning trace.
+     * @param toolCalls - Map of tool-call blocks, keyed by their stream index.
+     * @returns An ordered array of content blocks.
+     */
+    _accDataToBlocks(
+        text: string,
+        thinking: string,
+        toolCalls: Map<string, ToolCallBlock>
+    ): (TextBlock | ThinkingBlock | ToolCallBlock)[] {
+        const blocks: (TextBlock | ThinkingBlock | ToolCallBlock)[] = [];
+
+        if (thinking) {
+            blocks.push({ id: crypto.randomUUID(), type: 'thinking', thinking });
+        }
+        if (text) {
+            blocks.push({ id: crypto.randomUUID(), type: 'text', text });
+        }
+        toolCalls.forEach(value => {
+            blocks.push(value);
+        });
+
+        return blocks;
+    }
+}

--- a/packages/agentscope/src/model/index.ts
+++ b/packages/agentscope/src/model/index.ts
@@ -3,5 +3,6 @@ export { ChatResponse } from './response';
 export { ChatUsage } from './usage';
 export { DashScopeChatModel } from './dashscope-model';
 export { DeepSeekChatModel } from './deepseek-model';
+export { GrokChatModel } from './grok-model';
 export { OllamaChatModel } from './ollama-model';
 export { OpenAIChatModel } from './openai-model';


### PR DESCRIPTION
## Summary

Adds support for xAI's Grok API as a new chat model provider, closing #7.

This follows the same structural pattern as the existing `DeepSeekChatModel` (`src/model/deepseek-model.ts`), since xAI's `/v1/chat/completions` endpoint is OpenAI-compatible.

Closes #7

## What's included

- `src/model/grok-model.ts` — `GrokChatModel` class extending `ChatModelBase`
  - Streaming (SSE) and non-streaming response handling
  - Tool / function calling support
  - Chain-of-thought reasoning via `reasoning_effort` for `grok-3-mini-*` models
  - `presetGenParams` / `presetHeaders` passthrough, matching the DeepSeek model's configuration surface
- `src/model/grok-model.test.ts` — 11 test cases covering:
  - Streaming plain-text responses
  - Streaming reasoning (`thinking`) + text for mini models
  - Streaming tool-call argument accumulation across multiple chunks
  - Non-streaming plain-text and reasoning + tool-call responses
  - Error handling on non-2xx API responses
  - `_formatToolChoice` behavior, including the reasoning-model fallback to `'auto'`
  - `_formatToolSchemas` passthrough
  - Request body correctness (`reasoning_effort`, `presetGenParams`, endpoint URL, headers)
- Export added to `src/model/index.ts`:
  ```ts
  export { GrokChatModel } from './grok-model';
  ```

## Design notes

- Reuses `OpenAIChatFormatter` as the default formatter rather than introducing a Grok-specific one, since xAI's message format matches OpenAI's.
- Fixed a latent issue present in the DeepSeek reference implementation: in the streaming loop, `usage` is now only overwritten when a chunk actually contains it, instead of being reset to `undefined` on chunks that omit it. This avoids silently losing token-usage data if the final SSE chunk before `[DONE]` doesn't carry `usage`.

## Testing

```bash
pnpm --filter @agentscope-ai/agentscope test src/model/grok-model.test.ts
```

All 11 tests pass locally.

## Open questions / follow-ups

- Model naming in docs/tests currently follows the `grok-3-*` / `grok-3-mini-*` convention. xAI's current model lineup (`grok-4.3`, `grok-build-0.1`) may have changed how `reasoning_effort` gating works — flagging in case a maintainer wants this generalized beyond the `-mini` suffix check.
- Streaming tool-call delta shape was modeled on OpenAI/DeepSeek's format based on xAI's documented OpenAI-compatibility; not yet verified against a live xAI streaming response with tool calls.

## Checklist

- [x] Follows existing `DeepSeekChatModel` structural pattern
- [x] Unit tests added and passing
- [x] Exported from `src/model/index.ts`
- [x] `pnpm format` run before commit
- [ ] Verified against live xAI API (recommended before merge)
<img width="1440" height="900" alt="Screenshot 2026-07-08 at 9 36 52 AM" src="https://github.com/user-attachments/assets/aac4fd4f-b049-40c9-9834-1beecfe8d5f9" />

