### PR TITLE
feat(event): surface reply finished_reason and error

### DIFF
--- a/packages/agentscope/package.json
+++ b/packages/agentscope/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@agentscope-ai/agentscope",
-    "version": "0.0.11",
+    "version": "0.0.14",
     "description": "",
     "exports": {
         "./message": {

--- a/packages/agentscope/src/agent/agent.ts
+++ b/packages/agentscope/src/agent/agent.ts
@@ -17,6 +17,7 @@ import {
     ModelCallEndEvent,
     ModelCallStartEvent,
     ReplyEndEvent,
+    ReplyFinishedReason,
     ReplyStartEvent,
     TextBlockDeltaEvent,
     TextBlockEndEvent,
@@ -553,6 +554,7 @@ export class Agent {
             created_at: new Date().toISOString(),
             session_id: '',
             reply_id: this.replyId,
+            finished_reason: ReplyFinishedReason.COMPLETED,
         } as ReplyEndEvent;
 
         return createMsg({

--- a/packages/agentscope/src/event/index.ts
+++ b/packages/agentscope/src/event/index.ts
@@ -56,10 +56,58 @@ export interface ReplyStartEvent extends EventBase {
     role: 'user' | 'assistant' | 'system';
 }
 
+/** The reason a reply finished. */
+export enum ReplyFinishedReason {
+    COMPLETED = 'completed',
+    INTERRUPTED = 'interrupted',
+    EXCEED_MAX_ITERS = 'exceed_max_iters',
+    ERROR = 'error',
+}
+
+/**
+ * Classification of a fatal error that terminated a reply.
+ *
+ * Not model-specific: the status-derived members apply to any upstream
+ * service reached during a reply (chat model, embedding, TTS, MCP).
+ */
+export enum ErrorType {
+    /** 401 — credential missing or wrong. */
+    AUTHENTICATION = 'authentication',
+    /** 403 — authenticated but not allowed. */
+    PERMISSION = 'permission',
+    /** 429 — rate/quota exceeded. */
+    RATE_LIMIT = 'rate_limit',
+    /** 400 / 422 — malformed request. */
+    INVALID_REQUEST = 'invalid_request',
+    /** 5xx — an upstream service failed. */
+    UPSTREAM = 'upstream',
+    /** Network error / timeout — no HTTP status available. */
+    CONNECTION = 'connection',
+    /** Framework bug or otherwise unexpected exception. */
+    INTERNAL = 'internal',
+    /** Fallback when no better classification is possible. */
+    UNKNOWN = 'unknown',
+}
+
+/** Structured, UI-facing description of a fatal reply error. */
+export interface ErrorInfo {
+    /** Stable classification key; the frontend localizes off it. */
+    type: ErrorType;
+    /** Short, sanitized, human-readable description. */
+    message: string;
+}
+
 export interface ReplyEndEvent extends EventBase {
     type: EventType.REPLY_END;
     session_id: string;
     reply_id: string;
+    /** The reason this reply finished. */
+    finished_reason: ReplyFinishedReason;
+    /**
+     * Structured error info, populated only when
+     * `finished_reason === ReplyFinishedReason.ERROR`.
+     */
+    error?: ErrorInfo | null;
 }
 
 export interface ModelCallStartEvent extends EventBase {

--- a/packages/agentscope/src/message/append-event.test.ts
+++ b/packages/agentscope/src/message/append-event.test.ts
@@ -1,5 +1,5 @@
 import { Msg, createMsg, appendEvent } from './message';
-import { EventType, AgentEvent } from '../event';
+import { EventType, AgentEvent, ReplyFinishedReason } from '../event';
 import {
     ContentBlock,
     DataBlock,
@@ -135,9 +135,14 @@ describe('appendEvent', () => {
      * Creates a base message object for comparison in tests.
      * @param content
      * @param finishedAt
+     * @param finishedReason
      * @returns A plain message object for comparison.
      */
-    function base(content: ContentBlock[], finishedAt: string | null = null) {
+    function base(
+        content: ContentBlock[],
+        finishedAt: string | null = null,
+        finishedReason: ReplyFinishedReason | null = null
+    ) {
         return {
             id: REPLY_ID,
             name: 'TestAgent',
@@ -145,6 +150,8 @@ describe('appendEvent', () => {
             metadata: {},
             created_at: createdAt,
             finished_at: finishedAt,
+            finished_reason: finishedReason,
+            error: null,
             content,
         };
     }
@@ -162,6 +169,8 @@ describe('appendEvent', () => {
             metadata: m.metadata,
             created_at: m.created_at,
             finished_at: m.finished_at ?? null,
+            finished_reason: m.finished_reason ?? null,
+            error: m.error ?? null,
             content: m.content,
         };
     }
@@ -691,6 +700,7 @@ describe('appendEvent', () => {
             type: EventType.REPLY_END,
             reply_id: REPLY_ID,
             session_id: SESSION_ID,
+            finished_reason: ReplyFinishedReason.COMPLETED,
         });
         const finalContent = [
             ...s7bPrefix,
@@ -704,7 +714,7 @@ describe('appendEvent', () => {
                 'error'
             ),
         ];
-        groundTruths.push(base(finalContent, FIXED_END_TS));
+        groundTruths.push(base(finalContent, FIXED_END_TS, ReplyFinishedReason.COMPLETED));
 
         // Apply all events and check ground truths
         expect(events.length).toBe(groundTruths.length);

--- a/packages/agentscope/src/message/message.ts
+++ b/packages/agentscope/src/message/message.ts
@@ -11,7 +11,7 @@ import {
     URLSource,
 } from './block';
 import { base64ToBytes, bytesToBase64 } from '../_utils/common';
-import { AgentEvent, EventType } from '../event';
+import { AgentEvent, EventType, ReplyFinishedReason, ErrorInfo } from '../event';
 
 /** A chat message exchanged between agents or between an agent and a model. */
 export interface Msg {
@@ -29,6 +29,16 @@ export interface Msg {
     created_at: string;
     /** ISO-8601 finished timestamp. */
     finished_at?: string | null;
+    /**
+     * Terminal reason of this reply (error / interrupted / exceed_max_iters).
+     * Undefined/null until a REPLY_END event is applied.
+     */
+    finished_reason?: ReplyFinishedReason | null;
+    /**
+     * Structured error info, populated only when
+     * `finished_reason === ReplyFinishedReason.ERROR`.
+     */
+    error?: ErrorInfo | null;
     /** Usage information for the message, such as token counts. */
     usage?: {
         input_tokens: number;
@@ -283,6 +293,8 @@ export function appendEvent(msg: Msg, event: AgentEvent): Msg {
     switch (event.type) {
         case EventType.REPLY_END:
             msg.finished_at = event.created_at;
+            msg.finished_reason = event.finished_reason;
+            msg.error = event.error ?? null;
             break;
 
         case EventType.TEXT_BLOCK_START:


### PR DESCRIPTION
Mirror the Python SDK's reply-error surfacing so the shared event/message contract matches:

- Add ReplyFinishedReason, ErrorType, and ErrorInfo to the event module.
- ReplyEndEvent gains a required finished_reason and an optional error.
- Msg gains reply-level finished_reason and error fields; appendEvent persists both when a REPLY_END event is applied.
- Agent emits ReplyEndEvent with finished_reason COMPLETED.

## PR Title Format

Please ensure your PR title follows the Conventional Commits format:

- Format: `<type>(<scope>): <description>`
- Example: `feat(memory): add redis cache support`
- Allowed types: `feat`, `fix`, `docs`, `ci`, `refactor`, `test`, `chore`, `perf`, `style`, `build`, `revert`
- Description should start with a lowercase letter

## Linked Issues

> Linked issues will be **automatically closed** when this PR is merged.

- Closes #

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before the code is ready to be reviewed.

- [ ] This PR is linked to a related issue (see above)
- [ ] Code has been formatted with `pnpm format`
- [ ] Related documentation has been updated (e.g. links, examples, etc.)
- [ ] All tests are passing (`pnpm test`)
- [ ] Code is ready for review
