### PR TITLE
feat(model): add Anthropic chat model

### DIFF
--- a/packages/agentscope/package.json
+++ b/packages/agentscope/package.json
@@ -87,6 +87,7 @@
         "typescript": "^5.5.3"
     },
     "dependencies": {
+        "@anthropic-ai/sdk": "^0.111.0",
         "@cfworker/json-schema": "^4.1.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "gray-matter": "^4.0.3",

--- a/packages/agentscope/src/formatter/anthropic-chat-formatter.test.ts
+++ b/packages/agentscope/src/formatter/anthropic-chat-formatter.test.ts
@@ -1,0 +1,186 @@
+import { createMsg } from '../message';
+import { AnthropicChatFormatter } from './anthropic-chat-formatter';
+
+describe('AnthropicChatFormatter', () => {
+    const formatter = new AnthropicChatFormatter();
+
+    test('formats assistant tool calls and tool results', async () => {
+        const messages = await formatter.format({
+            msgs: [
+                createMsg({
+                    name: 'assistant',
+                    role: 'assistant',
+                    content: [
+                        {
+                            type: 'text',
+                            id: 'text-1',
+                            text: 'Let me check.',
+                            created_at: '2026-01-01T00:00:00.000Z',
+                        },
+                        {
+                            type: 'tool_call',
+                            id: 'toolu_1',
+                            name: 'get_weather',
+                            input: '{"city":"Beijing"}',
+                            state: 'pending',
+                            created_at: '2026-01-01T00:00:00.000Z',
+                        },
+                        {
+                            type: 'tool_result',
+                            id: 'toolu_1',
+                            name: 'get_weather',
+                            output: 'Sunny',
+                            state: 'success',
+                            created_at: '2026-01-01T00:00:01.000Z',
+                        },
+                    ],
+                }),
+            ],
+        });
+
+        expect(messages).toEqual([
+            {
+                role: 'assistant',
+                content: [
+                    {
+                        type: 'text',
+                        text: 'Let me check.',
+                    },
+                    {
+                        type: 'tool_use',
+                        id: 'toolu_1',
+                        name: 'get_weather',
+                        input: {
+                            city: 'Beijing',
+                        },
+                    },
+                ],
+            },
+            {
+                role: 'user',
+                content: [
+                    {
+                        type: 'tool_result',
+                        tool_use_id: 'toolu_1',
+                        content: 'Sunny',
+                        is_error: false,
+                    },
+                ],
+            },
+        ]);
+    });
+
+    test('marks failed tool results as errors', async () => {
+        const messages = await formatter.format({
+            msgs: [
+                createMsg({
+                    name: 'assistant',
+                    role: 'assistant',
+                    content: [
+                        {
+                            type: 'tool_result',
+                            id: 'toolu_2',
+                            name: 'get_weather',
+                            output: 'Service unavailable',
+                            state: 'error',
+                            created_at: '2026-01-01T00:00:00.000Z',
+                        },
+                    ],
+                }),
+            ],
+        });
+
+        expect(messages).toEqual([
+            {
+                role: 'user',
+                content: [
+                    {
+                        type: 'tool_result',
+                        tool_use_id: 'toolu_2',
+                        content: 'Service unavailable',
+                        is_error: true,
+                    },
+                ],
+            },
+        ]);
+    });
+
+    test('formats URL and base64 images', async () => {
+        const messages = await formatter.format({
+            msgs: [
+                createMsg({
+                    name: 'user',
+                    role: 'user',
+                    content: [
+                        {
+                            type: 'data',
+                            id: 'image-url',
+                            source: {
+                                type: 'url',
+                                url: 'https://example.com/image.png',
+                                media_type: 'image/png',
+                            },
+                            created_at: '2026-01-01T00:00:00.000Z',
+                        },
+                        {
+                            type: 'data',
+                            id: 'image-data',
+                            source: {
+                                type: 'base64',
+                                data: 'aW1hZ2U=',
+                                media_type: 'image/jpeg',
+                            },
+                            created_at: '2026-01-01T00:00:00.000Z',
+                        },
+                    ],
+                }),
+            ],
+        });
+
+        expect(messages).toEqual([
+            {
+                role: 'user',
+                content: [
+                    {
+                        type: 'image',
+                        source: {
+                            type: 'url',
+                            url: 'https://example.com/image.png',
+                        },
+                    },
+                    {
+                        type: 'image',
+                        source: {
+                            type: 'base64',
+                            data: 'aW1hZ2U=',
+                            media_type: 'image/jpeg',
+                        },
+                    },
+                ],
+            },
+        ]);
+    });
+
+    test('rejects invalid serialized tool input', async () => {
+        await expect(
+            formatter.format({
+                msgs: [
+                    createMsg({
+                        name: 'assistant',
+                        role: 'assistant',
+                        content: [
+                            {
+                                type: 'tool_call',
+                                id: 'toolu_invalid',
+                                name: 'get_weather',
+                                input: '{invalid',
+                                state: 'pending',
+                                created_at: '2026-01-01T00:00:00.000Z',
+                            },
+                        ],
+                    }),
+                ],
+            })
+        ).rejects.toThrow('Invalid JSON input for Anthropic tool call');
+    });
+});

--- a/packages/agentscope/src/formatter/anthropic-chat-formatter.ts
+++ b/packages/agentscope/src/formatter/anthropic-chat-formatter.ts
@@ -1,0 +1,164 @@
+import type Anthropic from '@anthropic-ai/sdk';
+
+import { DataBlock, Msg, TextBlock, ToolResultBlock, getContentBlocks } from '../message';
+import { FormatterBase } from './base';
+
+/**
+ * Format AgentScope messages for the Anthropic Messages API.
+ */
+export class AnthropicChatFormatter extends FormatterBase {
+    /**
+     * Format AgentScope messages into Anthropic message objects.
+     *
+     * System messages are kept in the returned array and moved to the top-level
+     * `system` request parameter by {@link AnthropicChatModel}.
+     *
+     * @param root0
+     * @param root0.msgs
+     * @returns Messages compatible with the Anthropic Messages API.
+     */
+    async format({ msgs }: { msgs: Array<Msg> }): Promise<Record<string, unknown>[]> {
+        const formattedMsgs: Anthropic.MessageParam[] = [];
+
+        for (const msg of msgs) {
+            const content: Anthropic.ContentBlockParam[] = [];
+            const toolResults: Anthropic.ToolResultBlockParam[] = [];
+
+            for (const block of getContentBlocks(msg)) {
+                switch (block.type) {
+                    case 'text':
+                        content.push(this._formatTextBlock(block));
+                        break;
+                    case 'thinking':
+                        // Thinking blocks cannot be sent back without their signature.
+                        break;
+                    case 'tool_call':
+                        content.push({
+                            type: 'tool_use',
+                            id: block.id,
+                            name: block.name,
+                            input: this._parseToolInput(block.input),
+                        });
+                        break;
+                    case 'tool_result':
+                        toolResults.push(this._formatToolResultBlock(block));
+                        break;
+                    case 'data': {
+                        const dataBlock = this._formatDataBlock(block);
+                        if (dataBlock) {
+                            content.push(dataBlock);
+                        }
+                        break;
+                    }
+                    case 'hint':
+                        break;
+                }
+            }
+
+            if (content.length > 0) {
+                formattedMsgs.push({
+                    role: msg.role,
+                    content,
+                });
+            }
+
+            // Anthropic requires tool results to be sent in a user message.
+            if (toolResults.length > 0) {
+                formattedMsgs.push({
+                    role: 'user',
+                    content: toolResults,
+                });
+            }
+        }
+
+        return formattedMsgs as unknown as Record<string, unknown>[];
+    }
+
+    /**
+     * Format a text block.
+     *
+     * @param block
+     * @returns An Anthropic text block.
+     */
+    _formatTextBlock(block: TextBlock): Anthropic.TextBlockParam {
+        return {
+            type: 'text',
+            text: block.text,
+        };
+    }
+
+    /**
+     * Parse a serialized AgentScope tool input.
+     *
+     * @param input
+     * @returns The parsed tool input.
+     */
+    protected _parseToolInput(input: string): unknown {
+        try {
+            return JSON.parse(input || '{}');
+        } catch {
+            throw new TypeError(`Invalid JSON input for Anthropic tool call: ${input}`);
+        }
+    }
+
+    /**
+     * Format a tool result block.
+     *
+     * @param block
+     * @returns An Anthropic tool result block.
+     */
+    protected _formatToolResultBlock(block: ToolResultBlock): Anthropic.ToolResultBlockParam {
+        const { text } = this.convertToolOutputToString(block.output, false);
+        return {
+            type: 'tool_result',
+            tool_use_id: block.id,
+            content: text,
+            is_error: ['error', 'interrupted', 'denied'].includes(block.state),
+        };
+    }
+
+    /**
+     * Format supported image data.
+     *
+     * @param block
+     * @returns An Anthropic image block, or null for unsupported media.
+     */
+    protected _formatDataBlock(block: DataBlock): Anthropic.ImageBlockParam | null {
+        if (!block.source.media_type.startsWith('image/')) {
+            console.log(
+                `Skip unsupported media type ${block.source.media_type} in AnthropicChatFormatter. Only images are supported.`
+            );
+            return null;
+        }
+
+        if (block.source.type === 'url') {
+            return {
+                type: 'image',
+                source: {
+                    type: 'url',
+                    url: block.source.url,
+                },
+            };
+        }
+
+        const supportedMediaTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'] as const;
+        if (
+            !supportedMediaTypes.includes(
+                block.source.media_type as (typeof supportedMediaTypes)[number]
+            )
+        ) {
+            throw new TypeError(
+                `Unsupported Anthropic image media type: ${block.source.media_type}`
+            );
+        }
+
+        return {
+            type: 'image',
+            source: {
+                type: 'base64',
+                media_type: block.source.media_type as (typeof supportedMediaTypes)[number],
+                data: block.source.data,
+            },
+        };
+    }
+}

--- a/packages/agentscope/src/formatter/index.ts
+++ b/packages/agentscope/src/formatter/index.ts
@@ -1,4 +1,5 @@
 export { FormatterBase } from './base';
+export { AnthropicChatFormatter } from './anthropic-chat-formatter';
 export { DashScopeChatFormatter } from './dashscope-chat-formatter';
 export { DeepSeekChatFormatter } from './deepseek-chat-formatter';
 export { OllamaChatFormatter } from './ollama-chat-formatter';

--- a/packages/agentscope/src/model/anthropic-model.test.ts
+++ b/packages/agentscope/src/model/anthropic-model.test.ts
@@ -1,0 +1,356 @@
+import type Anthropic from '@anthropic-ai/sdk';
+
+import { createMsg } from '../message';
+import { ToolSchema } from '../type';
+import { AnthropicChatModel } from './anthropic-model';
+import { ChatResponse } from './response';
+
+const toolSchema: ToolSchema = {
+    type: 'function',
+    function: {
+        name: 'get_weather',
+        description: 'Get the weather for a city.',
+        parameters: {
+            type: 'object',
+            properties: {
+                city: {
+                    type: 'string',
+                },
+            },
+            required: ['city'],
+        },
+    },
+};
+
+/**
+ * Create a model for unit tests.
+ *
+ * @param stream
+ * @returns A configured Anthropic model.
+ */
+function createModel(stream: boolean): AnthropicChatModel {
+    return new AnthropicChatModel({
+        modelName: 'claude-sonnet-4-6',
+        apiKey: 'test-api-key',
+        maxTokens: 512,
+        stream,
+    });
+}
+
+/**
+ * Create an async iterable from mock stream events.
+ *
+ * @param events
+ * @returns A mock Anthropic event stream.
+ */
+async function* createMockStream(
+    events: Anthropic.RawMessageStreamEvent[]
+): AsyncGenerator<Anthropic.RawMessageStreamEvent> {
+    for (const event of events) {
+        yield event;
+    }
+}
+
+describe('AnthropicChatModel', () => {
+    test('generates a non-streaming response with tool calls', async () => {
+        const response = {
+            id: 'msg_123',
+            type: 'message',
+            role: 'assistant',
+            model: 'claude-sonnet-4-6',
+            content: [
+                {
+                    type: 'text',
+                    text: 'I will check the weather.',
+                },
+                {
+                    type: 'tool_use',
+                    id: 'toolu_123',
+                    name: 'get_weather',
+                    input: {
+                        city: 'Beijing',
+                    },
+                },
+            ],
+            stop_reason: 'tool_use',
+            stop_sequence: null,
+            usage: {
+                input_tokens: 25,
+                output_tokens: 12,
+            },
+        } as unknown as Anthropic.Message;
+        const create = jest.fn().mockResolvedValue(response);
+        const model = createModel(false);
+        Object.assign(model['client'].messages, { create });
+
+        const result = (await model.call({
+            messages: [
+                createMsg({
+                    name: 'system',
+                    role: 'system',
+                    content: 'You are a helpful assistant.',
+                }),
+                createMsg({
+                    name: 'user',
+                    role: 'user',
+                    content: 'What is the weather in Beijing?',
+                }),
+            ],
+            tools: [toolSchema],
+            toolChoice: 'get_weather',
+        })) as ChatResponse;
+
+        expect(create).toHaveBeenCalledWith({
+            model: 'claude-sonnet-4-6',
+            max_tokens: 512,
+            messages: [
+                {
+                    role: 'user',
+                    content: [
+                        {
+                            type: 'text',
+                            text: 'What is the weather in Beijing?',
+                        },
+                    ],
+                },
+            ],
+            system: [
+                {
+                    type: 'text',
+                    text: 'You are a helpful assistant.',
+                },
+            ],
+            tools: [
+                {
+                    name: 'get_weather',
+                    description: 'Get the weather for a city.',
+                    input_schema: toolSchema.function.parameters,
+                },
+            ],
+            tool_choice: {
+                type: 'tool',
+                name: 'get_weather',
+            },
+            stream: false,
+        });
+        expect(result).toMatchObject({
+            id: 'msg_123',
+            type: 'chat',
+            content: [
+                {
+                    type: 'text',
+                    text: 'I will check the weather.',
+                },
+                {
+                    type: 'tool_call',
+                    id: 'toolu_123',
+                    name: 'get_weather',
+                    input: '{"city":"Beijing"}',
+                    state: 'pending',
+                },
+            ],
+            usage: {
+                inputTokens: 25,
+                outputTokens: 12,
+            },
+        });
+    });
+
+    test('omits tool parameters when no tools are provided', async () => {
+        const response = {
+            id: 'msg_text',
+            content: [
+                {
+                    type: 'text',
+                    text: 'Hello!',
+                },
+            ],
+            usage: {
+                input_tokens: 5,
+                output_tokens: 2,
+            },
+        } as unknown as Anthropic.Message;
+        const create = jest.fn().mockResolvedValue(response);
+        const model = createModel(false);
+        Object.assign(model['client'].messages, { create });
+
+        await model.call({
+            messages: [
+                createMsg({
+                    name: 'user',
+                    role: 'user',
+                    content: 'Hello',
+                }),
+            ],
+        });
+
+        const request = create.mock.calls[0][0];
+        expect(request).not.toHaveProperty('tools');
+        expect(request).not.toHaveProperty('tool_choice');
+    });
+
+    test('generates streaming text and tool call deltas', async () => {
+        const events = [
+            {
+                type: 'message_start',
+                message: {
+                    id: 'msg_stream',
+                    usage: {
+                        input_tokens: 30,
+                        output_tokens: 0,
+                    },
+                },
+            },
+            {
+                type: 'content_block_start',
+                index: 0,
+                content_block: {
+                    type: 'text',
+                    text: '',
+                },
+            },
+            {
+                type: 'content_block_delta',
+                index: 0,
+                delta: {
+                    type: 'text_delta',
+                    text: 'Checking ',
+                },
+            },
+            {
+                type: 'content_block_delta',
+                index: 0,
+                delta: {
+                    type: 'text_delta',
+                    text: 'the weather.',
+                },
+            },
+            {
+                type: 'content_block_start',
+                index: 1,
+                content_block: {
+                    type: 'tool_use',
+                    id: 'toolu_stream',
+                    name: 'get_weather',
+                    input: {},
+                },
+            },
+            {
+                type: 'content_block_delta',
+                index: 1,
+                delta: {
+                    type: 'input_json_delta',
+                    partial_json: '{"city"',
+                },
+            },
+            {
+                type: 'content_block_delta',
+                index: 1,
+                delta: {
+                    type: 'input_json_delta',
+                    partial_json: ':"Beijing"}',
+                },
+            },
+            {
+                type: 'message_delta',
+                delta: {
+                    stop_reason: 'tool_use',
+                    stop_sequence: null,
+                },
+                usage: {
+                    output_tokens: 18,
+                },
+            },
+            {
+                type: 'message_stop',
+            },
+        ] as unknown as Anthropic.RawMessageStreamEvent[];
+        const create = jest.fn().mockResolvedValue(createMockStream(events));
+        const model = createModel(true);
+        Object.assign(model['client'].messages, { create });
+
+        const result = (await model.call({
+            messages: [
+                createMsg({
+                    name: 'user',
+                    role: 'user',
+                    content: 'What is the weather in Beijing?',
+                }),
+            ],
+            tools: [toolSchema],
+            toolChoice: 'required',
+        })) as AsyncGenerator<ChatResponse, ChatResponse>;
+        const deltas: ChatResponse[] = [];
+        let completeResponse: ChatResponse | undefined;
+
+        while (true) {
+            const next = await result.next();
+            if (next.done) {
+                completeResponse = next.value;
+                break;
+            }
+            deltas.push(next.value);
+        }
+
+        expect(create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                stream: true,
+                tool_choice: {
+                    type: 'any',
+                },
+            })
+        );
+        expect(deltas.map(delta => delta.content)).toMatchObject([
+            [{ type: 'text', text: 'Checking ' }],
+            [{ type: 'text', text: 'the weather.' }],
+            [{ type: 'tool_call', input: '{"city"' }],
+            [{ type: 'tool_call', input: ':"Beijing"}' }],
+            [],
+        ]);
+        expect(completeResponse).toMatchObject({
+            id: 'msg_stream',
+            content: [
+                {
+                    type: 'text',
+                    text: 'Checking the weather.',
+                },
+                {
+                    type: 'tool_call',
+                    id: 'toolu_stream',
+                    name: 'get_weather',
+                    input: '{"city":"Beijing"}',
+                },
+            ],
+            usage: {
+                inputTokens: 30,
+                outputTokens: 18,
+            },
+        });
+    });
+
+    test('formats tool choice', () => {
+        const model = createModel(false);
+
+        expect(model['_formatToolChoice']()).toEqual({ type: 'auto' });
+        expect(model['_formatToolChoice']('auto')).toEqual({ type: 'auto' });
+        expect(model['_formatToolChoice']('none')).toEqual({ type: 'none' });
+        expect(model['_formatToolChoice']('required')).toEqual({ type: 'any' });
+        expect(model['_formatToolChoice']('get_weather')).toEqual({
+            type: 'tool',
+            name: 'get_weather',
+        });
+    });
+
+    test('formats tool schemas', () => {
+        const model = createModel(false);
+
+        expect(model['_formatToolSchemas']([toolSchema])).toEqual([
+            {
+                name: 'get_weather',
+                description: 'Get the weather for a city.',
+                input_schema: toolSchema.function.parameters,
+            },
+        ]);
+        expect(model['_formatToolSchemas']()).toEqual([]);
+    });
+});

--- a/packages/agentscope/src/model/anthropic-model.ts
+++ b/packages/agentscope/src/model/anthropic-model.ts
@@ -1,0 +1,421 @@
+import Anthropic from '@anthropic-ai/sdk';
+
+import { AnthropicChatFormatter } from '../formatter';
+import { TextBlock, ThinkingBlock, ToolCallBlock } from '../message';
+import { ToolChoice, ToolSchema } from '../type';
+import { ChatModelBase, ChatModelOptions, ChatModelRequestOptions } from './base';
+import { ChatResponse } from './response';
+import { ChatUsage } from './usage';
+
+interface AnthropicChatModelOptions extends ChatModelOptions {
+    /**
+     * The API key used to authenticate with Anthropic.
+     */
+    apiKey: string;
+
+    /**
+     * The maximum number of output tokens. Defaults to 8192.
+     */
+    maxTokens?: number;
+
+    /**
+     * Additional generation parameters included in every request.
+     */
+    presetGenParams?: Record<string, unknown>;
+
+    /**
+     * Override the Anthropic API base URL.
+     */
+    baseURL?: string;
+}
+
+/**
+ * The Anthropic Messages API chat model.
+ */
+export class AnthropicChatModel extends ChatModelBase {
+    protected client: Anthropic;
+    protected maxTokens: number;
+    protected presetGenParams: Record<string, unknown> | undefined;
+
+    /**
+     * Initialize an Anthropic chat model.
+     *
+     * @param options
+     * @param options.modelName
+     * @param options.apiKey
+     * @param options.stream
+     * @param options.maxTokens
+     * @param options.maxRetries
+     * @param options.fallbackModelName
+     * @param options.presetGenParams
+     * @param options.baseURL
+     * @param options.formatter
+     */
+    constructor({
+        modelName,
+        apiKey,
+        stream = true,
+        maxTokens = 8192,
+        maxRetries = 3,
+        fallbackModelName,
+        presetGenParams,
+        baseURL,
+        formatter,
+    }: AnthropicChatModelOptions) {
+        super({
+            modelName,
+            stream,
+            maxRetries,
+            fallbackModelName,
+            formatter: formatter || new AnthropicChatFormatter(),
+        });
+
+        this.client = new Anthropic({
+            apiKey,
+            baseURL,
+            maxRetries: 0,
+        });
+        this.maxTokens = maxTokens;
+        this.presetGenParams = presetGenParams;
+    }
+
+    /**
+     * Call the Anthropic Messages API.
+     *
+     * @param modelName
+     * @param options
+     * @returns A complete response or an async generator of streamed responses.
+     */
+    async _callAPI(
+        modelName: string,
+        options: ChatModelRequestOptions<Anthropic.MessageParam>
+    ): Promise<ChatResponse | AsyncGenerator<ChatResponse, ChatResponse>> {
+        const { messages, system } = this._extractSystemMessages(options.messages);
+        const tools = this._formatToolSchemas(options.tools);
+        const commonParams = {
+            model: modelName,
+            max_tokens: this.maxTokens,
+            messages,
+            ...(system.length > 0 && { system }),
+            ...(tools.length > 0 && {
+                tools,
+                tool_choice: this._formatToolChoice(options.toolChoice),
+            }),
+            ...(this.presetGenParams ?? {}),
+        };
+        const startTime = Date.now();
+
+        if (this.stream) {
+            const stream = await this.client.messages.create({
+                ...commonParams,
+                stream: true,
+            } as Anthropic.MessageCreateParamsStreaming);
+            return this._parseAnthropicStreamedResponse(stream, startTime);
+        }
+
+        const response = await this.client.messages.create({
+            ...commonParams,
+            stream: false,
+        } as Anthropic.MessageCreateParamsNonStreaming);
+
+        return this._parseAnthropicResponse(response, startTime);
+    }
+
+    /**
+     * Move system messages to Anthropic's top-level system parameter.
+     *
+     * @param messages
+     * @returns Regular conversation messages and system text blocks.
+     */
+    protected _extractSystemMessages(messages: Anthropic.MessageParam[]): {
+        messages: Anthropic.MessageParam[];
+        system: Anthropic.TextBlockParam[];
+    } {
+        const regularMessages: Anthropic.MessageParam[] = [];
+        const system: Anthropic.TextBlockParam[] = [];
+
+        for (const message of messages) {
+            if (message.role !== 'system') {
+                regularMessages.push(message);
+                continue;
+            }
+
+            if (typeof message.content === 'string') {
+                system.push({
+                    type: 'text',
+                    text: message.content,
+                });
+                continue;
+            }
+
+            for (const block of message.content) {
+                if (block.type === 'text') {
+                    system.push({
+                        type: 'text',
+                        text: block.text,
+                    });
+                }
+            }
+        }
+
+        return {
+            messages: regularMessages,
+            system,
+        };
+    }
+
+    /**
+     * Convert an Anthropic response into an AgentScope response.
+     *
+     * @param response
+     * @param startTime
+     * @returns The converted chat response.
+     */
+    protected _parseAnthropicResponse(
+        response: Anthropic.Message,
+        startTime: number
+    ): ChatResponse {
+        const blocks: (TextBlock | ThinkingBlock | ToolCallBlock)[] = [];
+
+        for (const block of response.content) {
+            if (block.type === 'text') {
+                blocks.push({
+                    type: 'text',
+                    id: crypto.randomUUID(),
+                    text: block.text,
+                    created_at: new Date().toISOString(),
+                });
+            } else if (block.type === 'thinking') {
+                blocks.push({
+                    type: 'thinking',
+                    id: crypto.randomUUID(),
+                    thinking: block.thinking,
+                    created_at: new Date().toISOString(),
+                });
+            } else if (block.type === 'tool_use') {
+                blocks.push({
+                    type: 'tool_call',
+                    id: block.id,
+                    name: block.name,
+                    input: JSON.stringify(block.input),
+                    state: 'pending',
+                    created_at: new Date().toISOString(),
+                });
+            }
+        }
+
+        return {
+            type: 'chat',
+            id: response.id,
+            createdAt: new Date().toISOString(),
+            content: blocks,
+            usage: {
+                type: 'chat_usage',
+                inputTokens: response.usage.input_tokens,
+                outputTokens: response.usage.output_tokens,
+                time: (Date.now() - startTime) / 1000,
+            },
+        };
+    }
+
+    /**
+     * Parse raw Anthropic streaming events.
+     *
+     * @param stream
+     * @param startTime
+     * @returns A generator yielding response deltas and returning the complete response.
+     */
+    protected async *_parseAnthropicStreamedResponse(
+        stream: AsyncIterable<Anthropic.RawMessageStreamEvent>,
+        startTime: number
+    ): AsyncGenerator<ChatResponse, ChatResponse> {
+        let responseId = '';
+        let accText = '';
+        let accThinking = '';
+        let inputTokens = 0;
+        let outputTokens = 0;
+        let lastUsage: ChatUsage | undefined;
+        const toolCallMeta = new Map<number, { id: string; name: string }>();
+        const toolInputs = new Map<number, string>();
+
+        for await (const event of stream) {
+            const deltaBlocks: (TextBlock | ThinkingBlock | ToolCallBlock)[] = [];
+
+            if (event.type === 'message_start') {
+                responseId = event.message.id;
+                inputTokens = event.message.usage.input_tokens;
+                outputTokens = event.message.usage.output_tokens;
+            } else if (
+                event.type === 'content_block_start' &&
+                event.content_block.type === 'tool_use'
+            ) {
+                toolCallMeta.set(event.index, {
+                    id: event.content_block.id,
+                    name: event.content_block.name,
+                });
+                toolInputs.set(event.index, '');
+            } else if (event.type === 'content_block_delta') {
+                if (event.delta.type === 'text_delta') {
+                    accText += event.delta.text;
+                    deltaBlocks.push({
+                        type: 'text',
+                        id: crypto.randomUUID(),
+                        text: event.delta.text,
+                        created_at: new Date().toISOString(),
+                    });
+                } else if (event.delta.type === 'thinking_delta') {
+                    accThinking += event.delta.thinking;
+                    deltaBlocks.push({
+                        type: 'thinking',
+                        id: crypto.randomUUID(),
+                        thinking: event.delta.thinking,
+                        created_at: new Date().toISOString(),
+                    });
+                } else if (event.delta.type === 'input_json_delta') {
+                    const meta = toolCallMeta.get(event.index);
+                    if (meta) {
+                        const input =
+                            (toolInputs.get(event.index) || '') + event.delta.partial_json;
+                        toolInputs.set(event.index, input);
+                        deltaBlocks.push({
+                            type: 'tool_call',
+                            id: meta.id,
+                            name: meta.name,
+                            input: event.delta.partial_json,
+                            state: 'pending',
+                            created_at: new Date().toISOString(),
+                        });
+                    }
+                }
+            } else if (event.type === 'message_delta') {
+                outputTokens = event.usage.output_tokens;
+                lastUsage = this._createUsage(inputTokens, outputTokens, startTime);
+            }
+
+            if (deltaBlocks.length > 0 || event.type === 'message_delta') {
+                yield {
+                    type: 'chat',
+                    id: responseId || crypto.randomUUID(),
+                    createdAt: new Date().toISOString(),
+                    content: deltaBlocks,
+                    usage: lastUsage,
+                };
+            }
+        }
+
+        const finalToolCalls = new Map<number, ToolCallBlock>();
+        for (const [index, meta] of toolCallMeta) {
+            finalToolCalls.set(index, {
+                type: 'tool_call',
+                id: meta.id,
+                name: meta.name,
+                input: toolInputs.get(index) || '{}',
+                state: 'pending',
+                created_at: new Date().toISOString(),
+            });
+        }
+
+        return {
+            type: 'chat',
+            id: responseId || crypto.randomUUID(),
+            createdAt: new Date().toISOString(),
+            content: this._dataToBlocks(accText, accThinking, finalToolCalls),
+            usage: lastUsage || this._createUsage(inputTokens, outputTokens, startTime),
+        };
+    }
+
+    /**
+     * Build a usage object.
+     *
+     * @param inputTokens
+     * @param outputTokens
+     * @param startTime
+     * @returns Chat usage.
+     */
+    protected _createUsage(
+        inputTokens: number,
+        outputTokens: number,
+        startTime: number
+    ): ChatUsage {
+        return {
+            type: 'chat_usage',
+            inputTokens,
+            outputTokens,
+            time: (Date.now() - startTime) / 1000,
+        };
+    }
+
+    /**
+     * Build final content blocks from accumulated stream data.
+     *
+     * @param text
+     * @param thinking
+     * @param toolCalls
+     * @returns Accumulated content blocks.
+     */
+    protected _dataToBlocks(
+        text: string,
+        thinking: string,
+        toolCalls: Map<number, ToolCallBlock>
+    ): (TextBlock | ThinkingBlock | ToolCallBlock)[] {
+        const blocks: (TextBlock | ThinkingBlock | ToolCallBlock)[] = [];
+
+        if (thinking) {
+            blocks.push({
+                type: 'thinking',
+                id: crypto.randomUUID(),
+                thinking,
+                created_at: new Date().toISOString(),
+            });
+        }
+        if (text) {
+            blocks.push({
+                type: 'text',
+                id: crypto.randomUUID(),
+                text,
+                created_at: new Date().toISOString(),
+            });
+        }
+        for (const toolCall of toolCalls.values()) {
+            blocks.push(toolCall);
+        }
+
+        return blocks;
+    }
+
+    /**
+     * Format AgentScope tool choice for Anthropic.
+     *
+     * @param toolChoice
+     * @returns Anthropic tool choice.
+     */
+    _formatToolChoice(toolChoice?: ToolChoice): Anthropic.ToolChoice {
+        if (!toolChoice || toolChoice === 'auto') {
+            return { type: 'auto' };
+        }
+        if (toolChoice === 'none') {
+            return { type: 'none' };
+        }
+        if (toolChoice === 'required') {
+            return { type: 'any' };
+        }
+        return {
+            type: 'tool',
+            name: toolChoice,
+        };
+    }
+
+    /**
+     * Format AgentScope tool schemas for Anthropic.
+     *
+     * @param tools
+     * @returns Anthropic tool definitions.
+     */
+    _formatToolSchemas(tools?: ToolSchema[]): Anthropic.Tool[] {
+        return (tools || []).map(tool => ({
+            name: tool.function.name,
+            description: tool.function.description,
+            input_schema: tool.function.parameters,
+        }));
+    }
+}

--- a/packages/agentscope/src/model/index.ts
+++ b/packages/agentscope/src/model/index.ts
@@ -1,6 +1,7 @@
 export { ChatModelBase } from './base';
 export { ChatResponse } from './response';
 export { ChatUsage } from './usage';
+export { AnthropicChatModel } from './anthropic-model';
 export { DashScopeChatModel } from './dashscope-model';
 export { DeepSeekChatModel } from './deepseek-model';
 export { OllamaChatModel } from './ollama-model';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,6 +242,9 @@ importers:
 
     packages/agentscope:
         dependencies:
+            '@anthropic-ai/sdk':
+                specifier: ^0.111.0
+                version: 0.111.0(zod@4.3.6)
             '@cfworker/json-schema':
                 specifier: ^4.1.1
                 version: 4.1.1
@@ -355,6 +358,18 @@ packages:
             {
                 integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==,
             }
+
+    '@anthropic-ai/sdk@0.111.0':
+        resolution:
+            {
+                integrity: sha512-1hUqKi+uJQoS5X90+InwHbFAXMvgq0DnsC5hVLEeSRaODiU5WvmqDAcVCmGS2wC0pN9Z8jtWCbWw7JLzeDdm/Q==,
+            }
+        hasBin: true
+        peerDependencies:
+            zod: ^3.25.0 || ^4.0.0
+        peerDependenciesMeta:
+            zod:
+                optional: true
 
     '@babel/code-frame@7.29.0':
         resolution:
@@ -3477,6 +3492,12 @@ packages:
                 integrity: sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==,
             }
 
+    '@stablelib/base64@1.0.1':
+        resolution:
+            {
+                integrity: sha512-0a0+q6JRqQm6kTma7g7sM8NvYF+AL9O19yCkmYpKPD7wIUBNE/bzgzY6dRIRHm2sTqqsgYq7mE17eVW5Lc7dmg==,
+            }
+
     '@szmarczak/http-timer@4.0.6':
         resolution:
             {
@@ -6578,6 +6599,12 @@ packages:
                 integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==,
             }
 
+    fast-sha256@1.3.0:
+        resolution:
+            {
+                integrity: sha512-n11RGP/l2JiU2oY7JOy1V67J2gNzU1yPgKAHzBFsO9/XhUncWbHGBQWuyIhBViVFiErBA7HmKo28+rtY3q6sDg==,
+            }
+
     fast-uri@3.1.0:
         resolution:
             {
@@ -7973,6 +8000,13 @@ packages:
             {
                 integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==,
             }
+
+    json-schema-to-ts@3.1.1:
+        resolution:
+            {
+                integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==,
+            }
+        engines: { node: '>=16' }
 
     json-schema-traverse@0.4.1:
         resolution:
@@ -10605,6 +10639,12 @@ packages:
             }
         engines: { node: '>=10' }
 
+    standardwebhooks@1.0.0:
+        resolution:
+            {
+                integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==,
+            }
+
     stat-mode@1.0.0:
         resolution:
             {
@@ -11002,6 +11042,12 @@ packages:
         resolution:
             {
                 integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==,
+            }
+
+    ts-algebra@2.0.0:
+        resolution:
+            {
+                integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==,
             }
 
     ts-api-utils@2.4.0:
@@ -11775,6 +11821,13 @@ snapshots:
         dependencies:
             package-manager-detector: 1.6.0
             tinyexec: 1.0.2
+
+    '@anthropic-ai/sdk@0.111.0(zod@4.3.6)':
+        dependencies:
+            json-schema-to-ts: 3.1.1
+            standardwebhooks: 1.0.0
+        optionalDependencies:
+            zod: 4.3.6
 
     '@babel/code-frame@7.29.0':
         dependencies:
@@ -14316,6 +14369,8 @@ snapshots:
         dependencies:
             '@sinonjs/commons': 3.0.1
 
+    '@stablelib/base64@1.0.1': {}
+
     '@szmarczak/http-timer@4.0.6':
         dependencies:
             defer-to-connect: 2.0.1
@@ -16464,6 +16519,8 @@ snapshots:
 
     fast-levenshtein@2.0.6: {}
 
+    fast-sha256@1.3.0: {}
+
     fast-uri@3.1.0: {}
 
     fault@1.0.4:
@@ -17502,6 +17559,11 @@ snapshots:
     json-buffer@3.0.1: {}
 
     json-parse-even-better-errors@2.3.1: {}
+
+    json-schema-to-ts@3.1.1:
+        dependencies:
+            '@babel/runtime': 7.28.6
+            ts-algebra: 2.0.0
 
     json-schema-traverse@0.4.1: {}
 
@@ -19402,6 +19464,11 @@ snapshots:
         dependencies:
             escape-string-regexp: 2.0.0
 
+    standardwebhooks@1.0.0:
+        dependencies:
+            '@stablelib/base64': 1.0.1
+            fast-sha256: 1.3.0
+
     stat-mode@1.0.0: {}
 
     statuses@2.0.2: {}
@@ -19647,6 +19714,8 @@ snapshots:
     truncate-utf8-bytes@1.0.2:
         dependencies:
             utf8-byte-length: 1.0.5
+
+    ts-algebra@2.0.0: {}
 
     ts-api-utils@2.4.0(typescript@5.9.3):
         dependencies:


### PR DESCRIPTION
## Linked Issues

- Closes #6

## Description

Adds Anthropic Messages API support to the AgentScope TypeScript model package.

- Add `AnthropicChatModel` with streaming and non-streaming responses
- Support text, thinking, tool calls, tool choice, usage, system prompts, retries, and preset generation parameters
- Add `AnthropicChatFormatter` for text, images, tool calls, and tool results
- Export the model and formatter from their public entry points
- Add mock-based unit tests for requests, responses, streaming deltas, formatting, and error cases

## Testing

- 21 test suites passed
- 135 tests passed
- Package build passed, including type declarations
- Lint and formatting checks passed
- Frozen lockfile validation passed

## Checklist

- [x] This PR is linked to a related issue
- [x] Code has been formatted
- [x] Public API documentation is included in JSDoc
- [x] All tests are passing
- [x] Code is ready for review