### PR TITLE
build: stabilize package boundaries and smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,17 +77,7 @@ jobs:
               run: pnpm run build:agentscope
 
             - name: Test package installation
-              shell: bash
-              run: |
-                  cd packages/agentscope
-                  npm pack
-                  TARBALL=$(ls agentscope-ai-agentscope-*.tgz)
-                  mkdir -p ../../test-install
-                  cd ../../test-install
-                  npm init -y
-                  npm install "../packages/agentscope/$TARBALL"
-                  node -e "const { Agent } = require('@agentscope-ai/agentscope/agent'); console.log('CJS import successful:', typeof Agent === 'function');"
-                  node --input-type=module -e "import { Agent } from '@agentscope-ai/agentscope/agent'; console.log('ESM import successful:', typeof Agent === 'function');"
+              run: pnpm run test:package
 
             - name: Build Desktop app
               run: pnpm run build:desktop

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "dev:agentscope": "pnpm --filter @agentscope-ai/agentscope dev",
         "dev:desktop": "cd apps/desktop && pnpm dev",
         "test:agentscope": "pnpm --filter @agentscope-ai/agentscope test",
+        "test:package": "node scripts/package-smoke.mjs",
         "clean:agentscope": "pnpm --filter @agentscope-ai/agentscope clean",
         "format": "prettier --write . && eslint . --ext .ts,.tsx --fix",
         "prepare": "husky"

--- a/packages/agentscope/src/_utils/common.ts
+++ b/packages/agentscope/src/_utils/common.ts
@@ -1,6 +1,6 @@
 import { jsonrepair } from 'jsonrepair';
 
-import { JSONSerializableObject } from '../type';
+import type { JSONSerializableObject } from '../type';
 
 /**
  * Decode a base64 string to a Uint8Array.

--- a/packages/agentscope/src/agent/agent.ts
+++ b/packages/agentscope/src/agent/agent.ts
@@ -1,23 +1,12 @@
 import { z } from 'zod';
 
-import {
-    ContentBlock,
-    createMsg,
-    getContentBlocks,
-    Msg,
-    ToolCallBlock,
-    ToolResultBlock,
-} from '../message';
-import { ChatModelBase, ChatResponse, ChatUsage } from '../model';
-import { Toolkit, ToolResponse } from '../tool';
 import { ActingOptions, ObserveOptions, ReasoningOptions, ReplyOptions } from './interfaces';
-import {
+import { EventType, ReplyFinishedReason } from '../event';
+import type {
     AgentEvent,
-    EventType,
     ModelCallEndEvent,
     ModelCallStartEvent,
     ReplyEndEvent,
-    ReplyFinishedReason,
     ReplyStartEvent,
     TextBlockDeltaEvent,
     TextBlockEndEvent,
@@ -33,7 +22,15 @@ import {
     ToolResultStartEvent,
     ToolResultTextDeltaEvent,
 } from '../event';
-import { StorageBase } from '../storage';
+import type { ContentBlock, ToolCallBlock, ToolResultBlock } from '../message/block';
+import { createMsg, getContentBlocks } from '../message/message';
+import type { Msg } from '../message/message';
+import type { ChatModelBase } from '../model/base';
+import type { ChatResponse } from '../model/response';
+import type { ChatUsage } from '../model/usage';
+import type { StorageBase } from '../storage/base';
+import type { ToolResponse } from '../tool/response';
+import { Toolkit } from '../tool/toolkit';
 
 const DEFAULT_COMPRESSION_PROMPT =
     '<system-hint>You have been working on the task described above but have not yet completed it. ' +

--- a/packages/agentscope/src/agent/interfaces.ts
+++ b/packages/agentscope/src/agent/interfaces.ts
@@ -1,8 +1,9 @@
 import { z } from 'zod';
 
-import { ExternalExecutionResultEvent, UserConfirmResultEvent } from '../event';
-import { Msg, ToolCallBlock } from '../message';
-import { ToolChoice } from '../type';
+import type { ExternalExecutionResultEvent, UserConfirmResultEvent } from '../event';
+import type { ToolCallBlock } from '../message/block';
+import type { Msg } from '../message/message';
+import type { ToolChoice } from '../type';
 
 export interface ReplyOptions {
     msgs?: Msg | Msg[];

--- a/packages/agentscope/src/agent/test-compression.ts
+++ b/packages/agentscope/src/agent/test-compression.ts
@@ -1,9 +1,12 @@
 import * as readline from 'readline';
 
 import { Agent } from './agent';
-import { createMsg } from '../message';
-import { DashScopeChatModel } from '../model';
-import { Bash, Glob, Grep, Toolkit } from '../tool';
+import { createMsg } from '../message/message';
+import { DashScopeChatModel } from '../model/dashscope-model';
+import { Bash } from '../tool/bash';
+import { Glob } from '../tool/glob';
+import { Grep } from '../tool/grep';
+import { Toolkit } from '../tool/toolkit';
 
 // Enable debug logging
 process.env.DEBUG = '*';

--- a/packages/agentscope/src/event/index.ts
+++ b/packages/agentscope/src/event/index.ts
@@ -1,5 +1,5 @@
-import { DataBlock, TextBlock, ToolCallBlock, ToolResultBlock } from '../message';
-import { PermissionRule } from '../permission';
+import type { DataBlock, TextBlock, ToolCallBlock, ToolResultBlock } from '../message/block';
+import type { PermissionRule } from '../permission';
 
 export enum EventType {
     REPLY_START = 'REPLY_START',

--- a/packages/agentscope/src/formatter/base.ts
+++ b/packages/agentscope/src/formatter/base.ts
@@ -1,4 +1,6 @@
-import { Msg, TextBlock, DataBlock, createMsg } from '../message';
+import type { DataBlock, TextBlock } from '../message/block';
+import { createMsg } from '../message/message';
+import type { Msg } from '../message/message';
 
 /**
  * Base class for message formatters.

--- a/packages/agentscope/src/formatter/dashscope-chat-formatter.ts
+++ b/packages/agentscope/src/formatter/dashscope-chat-formatter.ts
@@ -1,6 +1,7 @@
 import { FormatterBase } from './base';
-import { Msg, TextBlock, getContentBlocks } from '../message';
-import { DataBlock } from '../message';
+import type { DataBlock, TextBlock } from '../message/block';
+import { getContentBlocks } from '../message/message';
+import type { Msg } from '../message/message';
 
 interface DashScopeFormatterOptions {
     /**

--- a/packages/agentscope/src/formatter/deepseek-chat-formatter.ts
+++ b/packages/agentscope/src/formatter/deepseek-chat-formatter.ts
@@ -1,5 +1,6 @@
 import { FormatterBase } from './base';
-import { Msg, getContentBlocks } from '../message';
+import { getContentBlocks } from '../message/message';
+import type { Msg } from '../message/message';
 
 interface DeepSeekFormatterOptions {
     /**

--- a/packages/agentscope/src/formatter/ollama-chat-formatter.ts
+++ b/packages/agentscope/src/formatter/ollama-chat-formatter.ts
@@ -1,5 +1,6 @@
 import { FormatterBase } from './base';
-import { Msg, getContentBlocks, getTextContent } from '../message';
+import { getContentBlocks, getTextContent } from '../message/message';
+import type { Msg } from '../message/message';
 
 /**
  * Format AgentScope message objects into Ollama Chat message format.

--- a/packages/agentscope/src/formatter/openai-chat-formatter.ts
+++ b/packages/agentscope/src/formatter/openai-chat-formatter.ts
@@ -4,7 +4,9 @@ import { extname } from 'path';
 import { fileURLToPath } from 'url';
 
 import { FormatterBase } from './base';
-import { DataBlock, Msg, TextBlock, getContentBlocks } from '../message';
+import type { DataBlock, TextBlock } from '../message/block';
+import { getContentBlocks } from '../message/message';
+import type { Msg } from '../message/message';
 
 interface OpenAIFormatterOptions {
     /**

--- a/packages/agentscope/src/mcp/base.ts
+++ b/packages/agentscope/src/mcp/base.ts
@@ -2,9 +2,10 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { CallToolRequest, CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
 import z from 'zod';
 
-import { Tool, ToolResponse } from '../tool';
+import type { Tool } from '../tool/base';
 import { createToolResponse } from '../tool/response';
-import { ToolInputSchema } from '../type';
+import type { ToolResponse } from '../tool/response';
+import type { ToolInputSchema } from '../type';
 
 /**
  * Type definition for getting a client instance

--- a/packages/agentscope/src/message/block.ts
+++ b/packages/agentscope/src/message/block.ts
@@ -1,4 +1,4 @@
-import { PermissionRule } from '../permission';
+import type { PermissionRule } from '../permission';
 
 export interface TextBlock {
     type: 'text';

--- a/packages/agentscope/src/message/message.ts
+++ b/packages/agentscope/src/message/message.ts
@@ -1,4 +1,4 @@
-import { JSONSerializableObject } from '../type';
+import type { JSONSerializableObject } from '../type';
 import {
     ContentBlock,
     TextBlock,
@@ -11,7 +11,8 @@ import {
     URLSource,
 } from './block';
 import { base64ToBytes, bytesToBase64 } from '../_utils/common';
-import { AgentEvent, EventType, ReplyFinishedReason, ErrorInfo } from '../event';
+import { EventType, ReplyFinishedReason } from '../event';
+import type { AgentEvent, ErrorInfo } from '../event';
 
 /** A chat message exchanged between agents or between an agent and a model. */
 export interface Msg {

--- a/packages/agentscope/src/model/base.ts
+++ b/packages/agentscope/src/model/base.ts
@@ -1,9 +1,10 @@
 import { z } from 'zod';
 
-import { ChatResponse, StructuredResponse } from './response';
-import { FormatterBase } from '../formatter';
-import { getTextContent, Msg } from '../message';
-import { ToolChoice, ToolInputSchema, ToolSchema } from '../type';
+import type { FormatterBase } from '../formatter/base';
+import { getTextContent } from '../message/message';
+import type { Msg } from '../message/message';
+import type { ToolChoice, ToolInputSchema, ToolSchema } from '../type';
+import type { ChatResponse, StructuredResponse } from './response';
 
 export interface ChatModelOptions {
     modelName: string;

--- a/packages/agentscope/src/model/dashscope-model.ts
+++ b/packages/agentscope/src/model/dashscope-model.ts
@@ -1,10 +1,10 @@
 import { ChatModelBase, ChatModelOptions, ChatModelRequestOptions } from './base';
 import { ChatResponse } from './response';
-import { DataBlock, TextBlock, ThinkingBlock, ToolCallBlock } from '../message';
-import { ToolChoice, ToolSchema } from '../type';
+import type { DataBlock, TextBlock, ThinkingBlock, ToolCallBlock } from '../message/block';
+import type { ToolChoice, ToolSchema } from '../type';
 import { ChatUsage } from './usage';
 import { _parseStreamedResponse } from '../_utils';
-import { DashScopeChatFormatter } from '../formatter';
+import { DashScopeChatFormatter } from '../formatter/dashscope-chat-formatter';
 
 interface _DashScopeStreamChunk {
     output?: {

--- a/packages/agentscope/src/model/deepseek-model.ts
+++ b/packages/agentscope/src/model/deepseek-model.ts
@@ -1,10 +1,10 @@
 import { ChatModelBase, ChatModelOptions, ChatModelRequestOptions } from './base';
 import { ChatResponse } from './response';
-import { DataBlock, TextBlock, ThinkingBlock, ToolCallBlock } from '../message';
-import { ToolChoice, ToolSchema } from '../type';
+import type { DataBlock, TextBlock, ThinkingBlock, ToolCallBlock } from '../message/block';
+import type { ToolChoice, ToolSchema } from '../type';
 import { ChatUsage } from './usage';
 import { _parseStreamedResponse } from '../_utils';
-import { DeepSeekChatFormatter } from '../formatter';
+import { DeepSeekChatFormatter } from '../formatter/deepseek-chat-formatter';
 
 interface _DeepSeekStreamChunk {
     choices?: {

--- a/packages/agentscope/src/model/ollama-model.ts
+++ b/packages/agentscope/src/model/ollama-model.ts
@@ -2,10 +2,10 @@ import { Ollama, ChatResponse as OllamaChatResponse, AbortableAsyncIterator } fr
 
 import { ChatModelBase, ChatModelOptions, ChatModelRequestOptions } from './base';
 import { ChatResponse } from './response';
-import { TextBlock, ThinkingBlock, ToolCallBlock } from '../message';
-import { ToolChoice, ToolSchema } from '../type';
+import type { TextBlock, ThinkingBlock, ToolCallBlock } from '../message/block';
+import type { ToolChoice, ToolSchema } from '../type';
 import { ChatUsage } from './usage';
-import { OllamaChatFormatter } from '../formatter';
+import { OllamaChatFormatter } from '../formatter/ollama-chat-formatter';
 
 interface OllamaThinkingConfig {
     /**

--- a/packages/agentscope/src/model/openai-model.ts
+++ b/packages/agentscope/src/model/openai-model.ts
@@ -4,12 +4,12 @@ import {
     ChatCompletionToolChoiceOption,
 } from 'openai/resources/chat/completions';
 
-import { DataBlock, TextBlock, ThinkingBlock, ToolCallBlock } from '../message';
-import { ToolChoice, ToolSchema } from '../type';
+import { OpenAIChatFormatter } from '../formatter/openai-chat-formatter';
+import type { DataBlock, TextBlock, ThinkingBlock, ToolCallBlock } from '../message/block';
+import type { ToolChoice, ToolSchema } from '../type';
 import { ChatModelBase, ChatModelOptions, ChatModelRequestOptions } from './base';
 import { ChatResponse } from './response';
 import { ChatUsage } from './usage';
-import { OpenAIChatFormatter } from '../formatter';
 
 interface OpenAIChatModelOptions extends ChatModelOptions {
     apiKey: string;

--- a/packages/agentscope/src/model/response.ts
+++ b/packages/agentscope/src/model/response.ts
@@ -1,6 +1,6 @@
-import { DataBlock, TextBlock, ThinkingBlock, ToolCallBlock } from '../message';
-import { JSONSerializableObject } from '../type';
-import { ChatUsage } from './usage';
+import type { DataBlock, TextBlock, ThinkingBlock, ToolCallBlock } from '../message/block';
+import type { JSONSerializableObject } from '../type';
+import type { ChatUsage } from './usage';
 
 export interface ChatResponse {
     type: 'chat';

--- a/packages/agentscope/src/model/usage.ts
+++ b/packages/agentscope/src/model/usage.ts
@@ -1,4 +1,4 @@
-import { JSONSerializableObject } from '../type';
+import type { JSONSerializableObject } from '../type';
 
 /**
  * The usage structure for chat models.

--- a/packages/agentscope/src/storage/base.ts
+++ b/packages/agentscope/src/storage/base.ts
@@ -1,4 +1,4 @@
-import { Msg } from '../message';
+import type { Msg } from '../message/message';
 
 /**
  * The complete agent state including both conversation context and metadata.

--- a/packages/agentscope/src/storage/file-system.ts
+++ b/packages/agentscope/src/storage/file-system.ts
@@ -3,8 +3,8 @@ import path from 'path';
 
 import * as mime from 'mime-types';
 
-import { Msg } from '../message';
 import { AgentState, StorageBase } from './base';
+import type { Msg } from '../message/message';
 
 /**
  * Local file system storage implementation.

--- a/packages/agentscope/src/tool/base.ts
+++ b/packages/agentscope/src/tool/base.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
-import { ToolResponse } from './response';
-import { ToolInputSchema } from '../type';
+import type { ToolInputSchema } from '../type';
+import type { ToolResponse } from './response';
 
 export interface Tool {
     name: string;

--- a/packages/agentscope/src/tool/response.ts
+++ b/packages/agentscope/src/tool/response.ts
@@ -1,5 +1,5 @@
-import { DataBlock, TextBlock } from '../message';
-import { JSONSerializableObject } from '../type';
+import type { DataBlock, TextBlock } from '../message/block';
+import type { JSONSerializableObject } from '../type';
 
 /**
  * The tool response structure.

--- a/packages/agentscope/src/tool/toolkit.ts
+++ b/packages/agentscope/src/tool/toolkit.ts
@@ -5,12 +5,13 @@ import { Validator } from '@cfworker/json-schema';
 import matter from 'gray-matter';
 import { z } from 'zod';
 
-import { createToolResponse, isToolResponse, ToolResponse } from './response';
-import { HTTPMCPClient, StdioMCPClient } from '../mcp';
-import { ToolCallBlock } from '../message';
-import { ToolInputSchema, ToolSchema } from '../type';
-import { Tool } from './base';
 import { _jsonLoadsWithRepair } from '../_utils';
+import { HTTPMCPClient } from '../mcp/http';
+import { StdioMCPClient } from '../mcp/stdio';
+import type { ToolCallBlock } from '../message/block';
+import type { ToolInputSchema, ToolSchema } from '../type';
+import type { Tool } from './base';
+import { createToolResponse, isToolResponse, ToolResponse } from './response';
 
 interface RegisteredTool extends Tool {
     type: 'function' | 'mcp';

--- a/packages/agentscope/src/type/index.ts
+++ b/packages/agentscope/src/type/index.ts
@@ -1,4 +1,4 @@
-import { ToolResponse } from '../tool';
+import type { ToolResponse } from '../tool/response';
 
 export type JSONSerializableObject =
     | string

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,9 +1,9 @@
 packages:
-  - 'packages/*'
-  - 'apps/*'
+    - 'packages/*'
+    - 'apps/*'
 allowBuilds:
-  electron: true
-  electron-winstaller: true
-  esbuild: true
-  typeit: true
-  unrs-resolver: true
+    electron: true
+    electron-winstaller: true
+    esbuild: true
+    typeit: true
+    unrs-resolver: true

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -24,6 +24,7 @@ function runNpm(arguments_) {
     return execFileSync(npmExecutable, arguments_, {
         cwd: temporaryRoot,
         encoding: 'utf8',
+        shell: process.platform === 'win32',
         stdio: ['ignore', 'pipe', 'inherit'],
     });
 }

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -12,6 +12,7 @@ const packageSpecifiers = Object.keys(packageJson.exports).map(subpath => {
     return `${packageJson.name}${subpath.slice(1)}`;
 });
 const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), 'agentscope-package-smoke-'));
+const npmExecutable = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 
 /**
  * Run an npm command in the isolated package consumer directory.
@@ -20,7 +21,7 @@ const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), 'agentscope-package-s
  * @returns {string} Standard output.
  */
 function runNpm(arguments_) {
-    return execFileSync('npm', arguments_, {
+    return execFileSync(npmExecutable, arguments_, {
         cwd: temporaryRoot,
         encoding: 'utf8',
         stdio: ['ignore', 'pipe', 'inherit'],

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -1,0 +1,70 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, '..');
+const packageRoot = path.join(repositoryRoot, 'packages/agentscope');
+const packageJson = JSON.parse(await readFile(path.join(packageRoot, 'package.json'), 'utf8'));
+const packageSpecifiers = Object.keys(packageJson.exports).map(subpath => {
+    return `${packageJson.name}${subpath.slice(1)}`;
+});
+const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), 'agentscope-package-smoke-'));
+
+/**
+ * Run an npm command in the isolated package consumer directory.
+ *
+ * @param {string[]} arguments_ npm arguments.
+ * @returns {string} Standard output.
+ */
+function runNpm(arguments_) {
+    return execFileSync('npm', arguments_, {
+        cwd: temporaryRoot,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'inherit'],
+    });
+}
+
+/**
+ * Run a Node.js expression in the isolated package consumer directory.
+ *
+ * @param {string[]} arguments_ Node.js arguments.
+ */
+function runNode(arguments_) {
+    execFileSync(process.execPath, arguments_, {
+        cwd: temporaryRoot,
+        stdio: 'inherit',
+    });
+}
+
+try {
+    const packOutput = runNpm(['pack', '--json', '--pack-destination', temporaryRoot, packageRoot]);
+    const packResult = JSON.parse(packOutput);
+    const tarballPath = path.join(temporaryRoot, packResult[0].filename);
+
+    runNpm(['init', '--yes']);
+    runNpm(['install', '--ignore-scripts', '--no-audit', '--no-fund', tarballPath]);
+
+    const specifiersJson = JSON.stringify(packageSpecifiers);
+    runNode([
+        '-e',
+        `for (const specifier of ${specifiersJson}) { ` +
+            `const value = require(specifier); ` +
+            `if (!value || typeof value !== 'object') throw new Error(specifier); }`,
+    ]);
+    runNode([
+        '--input-type=module',
+        '-e',
+        `for (const specifier of ${specifiersJson}) { ` +
+            `const value = await import(specifier); ` +
+            `if (!value || typeof value !== 'object') throw new Error(specifier); }`,
+    ]);
+
+    process.stdout.write(
+        `Package smoke test passed for ${packageSpecifiers.length} ESM and CJS exports.\n`
+    );
+} finally {
+    await rm(temporaryRoot, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Linked Issues

- Related to #49

## Description

### Background and purpose

This is the first independently reviewable PR extracted from the preserved #48 snapshot. It stabilizes package boundaries and packed-package validation before Python parity features are introduced.

### Changes

- Replace internal barrel imports with direct runtime imports and `import type` where appropriate.
- Add a platform-neutral package smoke script.
- Verify every currently published subpath through ESM and CommonJS after `npm pack`.
- Reuse the smoke script in CI instead of shell-specific inline commands.
- Normalize `pnpm-workspace.yaml` to the repository's current Prettier output.

### Scope

This PR contains no new public APIs, Python parity data, runtime behavior changes, or Service/Desktop architecture changes.

### Review guide

1. Review `packages/agentscope/src/**`: these edits only replace barrel imports with direct value/type imports.
2. Review `scripts/package-smoke.mjs`: it packs the package into a temporary directory, installs it, and loads every existing export through ESM and CommonJS.
3. Review the small CI and package-script changes last.

### Verification

```bash
npx --yes pnpm@9.15.9 install --frozen-lockfile
npx --yes pnpm@9.15.9 format
npx --yes pnpm@9.15.9 run build:agentscope
npx --yes pnpm@9.15.9 run test:package
npx --yes pnpm@9.15.9 run test:agentscope
npx --yes pnpm@9.15.9 run build:desktop
```

Local verification passed:

- Core ESM/CJS/DTS build.
- Packed-package smoke for 10 ESM and 10 CommonJS exports.
- 126 Core tests.
- Desktop typecheck and build.
- Formatting with no diff.

GitHub Actions passed on Ubuntu, macOS, and Windows.

### Dependency

- Base: `main`
- Depends on: none
- Can be reviewed independently from #51
- Full snapshot for reference only: `rayrayraykk:feat/parity-foundation`

## Checklist

- [x] This PR is linked to a related issue (see above)
- [x] Code has been formatted with `pnpm format`
- [x] Related documentation has been updated (not applicable: no user-facing behavior changes)
- [x] All tests are passing (`pnpm test` and the focused commands above)
- [x] Code is ready for review
