### PR TITLE
test(parity): add pinned Python manifest checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,32 @@ on:
             - main
 
 jobs:
+    parity-manifest:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout TypeScript repository
+              uses: actions/checkout@v4
+
+            - name: Checkout pinned Python baseline
+              uses: actions/checkout@v4
+              with:
+                  repository: agentscope-ai/agentscope
+                  ref: de163b34b909edaba3c174190ad7e1a355e7849f
+                  path: python-baseline
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20.x
+
+            - name: Test parity tooling
+              run: node --test scripts/parity/*.test.mjs
+
+            - name: Verify parity manifest against Python
+              run: >-
+                  node scripts/parity/check-manifest.mjs
+                  --python-root python-baseline
+
     lint:
         runs-on: ubuntu-latest
         steps:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
         "build:desktop": "cd apps/desktop && pnpm build",
         "dev:agentscope": "pnpm --filter @agentscope-ai/agentscope dev",
         "dev:desktop": "cd apps/desktop && pnpm dev",
+        "parity:check": "node scripts/parity/check-manifest.mjs",
+        "parity:generate": "node scripts/parity/generate-manifest.mjs",
         "test:agentscope": "pnpm --filter @agentscope-ai/agentscope test",
+        "test:parity": "node --test scripts/parity/*.test.mjs",
         "clean:agentscope": "pnpm --filter @agentscope-ai/agentscope clean",
         "format": "prettier --write . && eslint . --ext .ts,.tsx --fix",
         "prepare": "husky"

--- a/parity/README.md
+++ b/parity/README.md
@@ -1,0 +1,29 @@
+# Python parity baseline
+
+This directory records every file under the AgentScope Python source and test trees. YAML model
+cards are tracked as contract data; all other source files, including package metadata, Alembic
+assets, and Dockerfile templates, are tracked as source. Test fixtures are tracked with test files.
+
+The manifest is not a claim that a mapped file is already implemented. Each source and contract
+data entry progresses through these states:
+
+1. `mapped`: a TypeScript destination is assigned.
+2. `contracted`: public and behavioral contracts have tests or golden fixtures.
+3. `implemented`: the TypeScript implementation passes its focused tests.
+4. `verified`: cross-language and integration verification is complete.
+
+No skipped or platform-not-applicable state exists. Platform-specific features are implemented and
+verified on their target operating system, while unsupported hosts expose an explicit capability or
+error contract.
+
+## Commands
+
+```bash
+pnpm parity:generate -- --python-root ../agentscope-python
+pnpm parity:check
+pnpm parity:check -- --python-root ../agentscope-python
+pnpm test:parity
+```
+
+The generator intentionally reads a separate Python checkout. The committed manifest allows normal
+TypeScript work without requiring Python, while CI checks it against the pinned Python commit.

--- a/parity/agentscope-python-de163b34.json
+++ b/parity/agentscope-python-de163b34.json
@@ -1,0 +1,5574 @@
+{
+    "schemaVersion": 1,
+    "pythonRepository": "https://github.com/agentscope-ai/agentscope.git",
+    "pythonCommit": "de163b34b909edaba3c174190ad7e1a355e7849f",
+    "sourceFiles": [
+        {
+            "path": "src/agentscope/__init__.py",
+            "sha256": "35f7f2cc6424dac7606dc1a247bc6fb7bcf1b8b2a208fccd9d3d5046980e7a54",
+            "module": "root",
+            "typescriptTarget": "packages/agentscope/src/index.ts",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/_logging.py",
+            "sha256": "5f37144dbecc7d166473e077375215fa3a476991b4c858ab6727ee19aec7380e",
+            "module": "root",
+            "typescriptTarget": "packages/agentscope/src/logger",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/_utils/__init__.py",
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "module": "_utils",
+            "typescriptTarget": "packages/agentscope/src/utils",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/_utils/_audio.py",
+            "sha256": "d98783891c95aa12e277ffcc9e18bcce5a662c9b4ab13bc515d4541a41816402",
+            "module": "_utils",
+            "typescriptTarget": "packages/agentscope/src/utils",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/_utils/_common.py",
+            "sha256": "5184d0bbded4525fdc8ca97456072ecfeb8a1b4b7e3aa961e22ee651f5e9fd80",
+            "module": "_utils",
+            "typescriptTarget": "packages/agentscope/src/utils",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/_utils/_mixin.py",
+            "sha256": "e3b4b22f8809bfa465f49c348ff0c5855b52fa077295630e9bf5d06263b3dda9",
+            "module": "_utils",
+            "typescriptTarget": "packages/agentscope/src/utils",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/_version.py",
+            "sha256": "42db2c9b32c8aef9cd562ac06752e9dcd260493c5f5df637de10bcd0a84bda92",
+            "module": "root",
+            "typescriptTarget": "packages/agentscope/src/version.ts",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/agent/__init__.py",
+            "sha256": "121b5555e73cf219f801f8fa0229370d90c38050ec63b33d6b75e72e69f754d2",
+            "module": "agent",
+            "typescriptTarget": "packages/agentscope/src/agent",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/agent/_agent.py",
+            "sha256": "236307c110ea3bcd2c089475ac0987bca2b596e2be7a36fd0ea22ec274b14521",
+            "module": "agent",
+            "typescriptTarget": "packages/agentscope/src/agent",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/agent/_config.py",
+            "sha256": "8bf9274347fc1895090dd5ee27d9ece67ddf5ba365d244bbc59de6b8a5bc4e74",
+            "module": "agent",
+            "typescriptTarget": "packages/agentscope/src/agent",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/agent/_structured_output_tool.py",
+            "sha256": "767f12345b2661c874a20e15a6101c4c3e3716624d5fb1e4623c33866d771a99",
+            "module": "agent",
+            "typescriptTarget": "packages/agentscope/src/agent",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/agent/_utils.py",
+            "sha256": "df29d1d7e9174f62aefb150a00d4dc3fd94479f3340e9a4ecb352c794b888bc2",
+            "module": "agent",
+            "typescriptTarget": "packages/agentscope/src/agent",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/__init__.py",
+            "sha256": "3c702f893055935cf596310ce98dc02a685145d6c5cb3df8f9cb83f1db68e14c",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_app.py",
+            "sha256": "f5024c783fddb80e5b0903d88b8d3b1fe8e198bbc18525ecd5986ff46c0b578c",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_bus_ops.py",
+            "sha256": "e804ae14352e96cb7d2105344e1e8f44f0c194dd05c0ad0d4ea31e476fc17069",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_lifespan.py",
+            "sha256": "21fe41b3dd24b812010da6909995124ade97cb18c2e355e78e7cd460067a3a7c",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_manager/__init__.py",
+            "sha256": "6d8d601b6c596cbe2ebc81624e39012e50073cb6be43f0efa44a447856ef1fdd",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-manager",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_manager/_background_task_manager.py",
+            "sha256": "c19963cb5bfff4771ab64be91ec9497cb3a1e6f2323fd536b9c07f39f4355bac",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-manager",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_manager/_cancel_dispatcher.py",
+            "sha256": "9e6f4d4c76c3e41b1471ffbf4f3c5fd2a596141e4b66e69ed0aa12cdc41e6ae4",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-manager",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_manager/_chat_run_registry.py",
+            "sha256": "c2d30d3a2b6b8428539eee55d80fcd52cb903831f48570f9ba002b78ceec409f",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-manager",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_manager/_scheduler/__init__.py",
+            "sha256": "b40b8de05274d4f61aa843fd233b835170f784001173075a9e1426e165764f6d",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-manager/-scheduler",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_manager/_scheduler/_scheduler_manager.py",
+            "sha256": "4a3c1da3380033f316bda7b2e6f450b0000b7d37665231655c22080d95fe8281",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-manager/-scheduler",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_manager/_scheduler/_tools/__init__.py",
+            "sha256": "cd15d62748129ec5bbe45aafdaff8c23dd72785a1188a5ad01d22bc6169d6277",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-manager/-scheduler/-tools",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_manager/_scheduler/_tools/_schedule_create.py",
+            "sha256": "da3d8dce6af15bfa3f3315b063dd220548aa52a4276834c05f8737f40401e50c",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-manager/-scheduler/-tools",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_manager/_scheduler/_tools/_schedule_delete.py",
+            "sha256": "d49fa266c3f01cd04ccd0f7c60609ffeebcc11d8027f1ad7f5a5cad5c1c35ff3",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-manager/-scheduler/-tools",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_manager/_scheduler/_tools/_schedule_list.py",
+            "sha256": "6a83addbb4697d30bd09e151a89bab235923a0b8f570864c48ac4d31bebce625",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-manager/-scheduler/-tools",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_manager/_scheduler/_tools/_schedule_view.py",
+            "sha256": "d40afc5fb2477023872847adeb6eb37ca2e5ba3c2f5278af2132f1b205a7db70",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-manager/-scheduler/-tools",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_manager/_wakeup_dispatcher.py",
+            "sha256": "1ff38a9aa3a1cdfa68cf4d15f9ccd6c02adbb22c886a87d374f28717fa66130c",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-manager",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/__init__.py",
+            "sha256": "81e0e6195a6934364667caacfd894018deb904af136ab121cd61e88d9b5d6597",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_agent.py",
+            "sha256": "7c0306f85ea2b01e4d3d7d0c3f07d545f9f6b4592a244efa7c3a5464363461e4",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_channel.py",
+            "sha256": "5f4dd12788545e13ee4f6ea5afac3984fea9582871cb5f2403fbeeae50aec13d",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_chat.py",
+            "sha256": "615cdef8034b32b854e86382761fb4245b1dd3a4c12f64f9bd6c7240fc851b84",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_credential.py",
+            "sha256": "46f7162eef621bbaff2fa5cc232f264a02887acf0d5c4eaa9385a028835a5b06",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_embedding_model.py",
+            "sha256": "b11ae54c56e37e8a0569e8d32788c58090ef86ebe83a2954cd653c49b2e61449",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_health.py",
+            "sha256": "b05e82fc7dfd6969fe6cad91e088357db90cc1886abdca1f300fd6f31f6f1304",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_hub.py",
+            "sha256": "e1c4129bea4aa5862f37431bdb88251dce7bf742d0aca10c0dd184c132e16175",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_knowledge_base.py",
+            "sha256": "6ae42e041ed41d35927318c36e411d8839fb2d51621361675d9258788fae9689",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_mcp.py",
+            "sha256": "c56fe33d16cdd6f210931e63f90a096a80ebe8bf098e9d12d745be0329766bfa",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_model.py",
+            "sha256": "421f3d7bb01340bc291e2c8fdc5822079ffc1ecf55ca502cfeffdb2509f6a6f2",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_schedule.py",
+            "sha256": "f5824ce0058e06f834f9a500cc92b9cd2face27a093e72ff7991fa7b4c811ec1",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_schema/__init__.py",
+            "sha256": "bc44de32cebd21abb7b6ceab0c2e7fe15db9966629b04aa2b5a5e98095466f4f",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router/-schema",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_schema/_agent.py",
+            "sha256": "5ae7593e937a17535cdcfa761d7d20d1abc7133eaf5f4dc531e17603c33f8f6d",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router/-schema",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_schema/_channel.py",
+            "sha256": "13c392f0d92fd73c853b687e940902190fe0911ac0c6f6af29f4e156ea778de6",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router/-schema",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_schema/_chat.py",
+            "sha256": "240077f53fa4c77b6d02381c5cf92f088e70a0f47ac7841ff8b76aeb63b64ab7",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router/-schema",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_schema/_credential.py",
+            "sha256": "89b3fb3f520631c49b0a3ac34a262d566b3a87e16566c3bed8c5a9b047e6ebd8",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router/-schema",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_schema/_embedding_model.py",
+            "sha256": "0ad24b2be66b0a687cf6d206224f14f33590ce8b8a36c56911b93059474b2e77",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router/-schema",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_schema/_health.py",
+            "sha256": "f10e1fd88d59877ec6f79ffa25778476fff7f26356507ebfb745201e732137aa",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router/-schema",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_schema/_hub_mcp.py",
+            "sha256": "29ac1559192e17070011c018d2ecc9d6a8df50c29666899eb1c7e84b1e2a58ff",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router/-schema",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_schema/_hub_skill.py",
+            "sha256": "a617737418b6fe57a30283f77f48d182546549f43a989135654131dbc1834b2b",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router/-schema",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_schema/_hub.py",
+            "sha256": "d41c2b085d411f6dfbe437f3b85997cbddba629836d6e65f337f8243d8b82f16",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router/-schema",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_schema/_knowledge_base.py",
+            "sha256": "69b807203382ecc687b60179e4cc65979ea71738229ce98c393fc1df7785f8af",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router/-schema",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_schema/_mcp.py",
+            "sha256": "c1f9aff4a336a354aff79beb448320c6309d4143d91297ce61536fa2129308c7",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router/-schema",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_schema/_model.py",
+            "sha256": "0425f9f0a12f8702a55f09206bd827a38bf4af0e1965002a78198fb683588e51",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router/-schema",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_schema/_schedule.py",
+            "sha256": "d6f5c457d80e8d712843fd235754ac349fa762b56ae91c361eecdc35a7f00b60",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router/-schema",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_schema/_session.py",
+            "sha256": "4d56488a8af70ec938457e4dac9039836430f86b2e29e21f4c675b862c217f9f",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router/-schema",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_schema/_tts_model.py",
+            "sha256": "ca94cf7910b9eb3c1f472ff326aebee8878450515508a1ec2c115beb2f032912",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router/-schema",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_schema/_workspace.py",
+            "sha256": "ab960392bfd2617db64962b81f02ca623315c4926c4e181c9081af72b2c31001",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router/-schema",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_session.py",
+            "sha256": "070f6e09f4cb65a21858df8e3e468996fd7ffb5c0fdf0c930a3105dfca222af8",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_skill.py",
+            "sha256": "8f1c3d559d89cf9076376d9c9156b54a630d3a078e12ab9b1075dd3362e98251",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_tts_model.py",
+            "sha256": "7313c82d5d25ae400c50c4795c95d91dd290f4ecf039e1274d23212fc430544b",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_router/_workspace.py",
+            "sha256": "08fbad0cbbe39d4a3c9a0580ff778463b8a246206fed4fe0cc3be4d1d67a4d89",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-router",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_service/__init__.py",
+            "sha256": "73685da0fac80b705cc9327e7cb06997ae3b99243fa5101b9352627779e041d1",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-service",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_service/_access.py",
+            "sha256": "e39616a84c3d4db7989273bb3901398a80c8df273ecdf9ec6208b27c93c4d253",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-service",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_service/_channel.py",
+            "sha256": "8e2e3f613535f10e13edb569f390f349e5ca3388f89baf42cf5bcb9b994807d3",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-service",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_service/_chat.py",
+            "sha256": "55482e7bcb87a1900da03f42c8746599e233e64b4d1ecd6a7ed687d6ddf72fed",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-service",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_service/_download_token.py",
+            "sha256": "04eb009aa232f9870e413385aaacc057f9350a6e06815811ed51f5bb82c620b2",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-service",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_service/_embedding.py",
+            "sha256": "a047a19fdbf8dc7d549a8f77c3bfdd62193a1b21116af5658475d749e1de3e64",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-service",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_service/_errors.py",
+            "sha256": "d8f63894715ddc016111cf8fbf1d6d167ceef8a03554e816061aae8c1d06e781",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-service",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_service/_index_sweeper.py",
+            "sha256": "7dd0564ff946271e3780f337c9b817fb4babfa8888afab105d4dc51f0f6fdb5d",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-service",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_service/_index_task_consumer.py",
+            "sha256": "c1a95bd7eff788718963d9f1583626b1acb91b4f07fd597040b8617c81ad6dab",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-service",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_service/_index_worker.py",
+            "sha256": "032b32a1065e2a5430396f7da76e3258b6d2b0c83ec0d607f6eb26c2bc885cac",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-service",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_service/_knowledge_base.py",
+            "sha256": "f3e54526723279fd31491af5e1dfce301f3e1d338892b67bdd0511df16f2dad8",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-service",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_service/_mcp_render.py",
+            "sha256": "5723485ae7e1ac41e837ea25a0112d13b938de79b3c90ca8cee4049b2e985fcb",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-service",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_service/_model.py",
+            "sha256": "29fb3783c3d8ee7e261f1fe9c17e504056fc4d838e56f2ff5702627c935bcaec",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-service",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_service/_projectors/__init__.py",
+            "sha256": "03a3e86db70ea2e307565b7296c7e61172ca1b10547896deeb06ba39f9417d10",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-service/-projectors",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_service/_projectors/_subagent_hitl.py",
+            "sha256": "b0db146fb396c1479043d2c26334f91c269a5bf186e18decff2e5244537b80f6",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-service/-projectors",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_service/_session_projection.py",
+            "sha256": "d5ff9458dae38a7a82529b4881186090a8271482a24e82443ff67ce8a2c83d40",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-service",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_service/_session.py",
+            "sha256": "59b0f0f7304f67b3fed3eb6f277f852d3cc57ce5f6498089ec4f4ef30fa800b8",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-service",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_service/_toolkit.py",
+            "sha256": "55fb376af9553f8b25031bd8708cb1b4dec61901d19df3274b421631c9de6027",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-service",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_service/_tts_model.py",
+            "sha256": "ef96120346da5f261d73cd9a22d5075e473b74d858a12c275a5ba92d9f020b64",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-service",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_service/_workspace.py",
+            "sha256": "d352a32649ec7adcf6f1b5072d5468b409ff6502b9dcc476ed474d0ed8fe7a5d",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-service",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_tool/__init__.py",
+            "sha256": "79bc3e0a334954680f3163e354dc01d695f2ae98c250d522953316c08a0530e0",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_tool/_agent_create.py",
+            "sha256": "588688d07bcf3ffea771dd07199332f87658c68a27c7dd3f81f013194b11b670",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_tool/_agent_invite.py",
+            "sha256": "7b4754bc4f0e4bd73c2589af72efcd56479e8b9d4646da8985ce137dad846918",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_tool/_constants.py",
+            "sha256": "614b0c046dc847ef7889bcd6e1a62f270e5f00462b384909992f73226b29110f",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_tool/_team_create.py",
+            "sha256": "7f6fab753bc7ebf9934b7d19177c98de8e806ba7ffceb7838840a02b6a92db45",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_tool/_team_delete.py",
+            "sha256": "e92f13f25a7f69c803b75a28ba8db7fd622559b0b085025581b94167042e8f6d",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_tool/_team_say.py",
+            "sha256": "2821bb337d50032c787933a663a391216816f30b10384307f8b72c7b0be88578",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_tool/_team_tool_base.py",
+            "sha256": "b5b1b92f95c47e56931ec6a73bfd4c63b48ff3ffcd4adaf75267ed7db413dfc5",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/-tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/_types.py",
+            "sha256": "3f7d68e31100f61e8f94a5e7c3601c4ed9fff53edca8d22ce268013f174e964f",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/access/__init__.py",
+            "sha256": "92b5804f6629d1ce754ca6860599a22f8885f73cc664d5635ed90f9a9828a8c3",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/access",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/access/_policy.py",
+            "sha256": "f63506c7a4957d194e09e290e15505e1fe369fa14189eada35ab38e3c6012f71",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/access",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/__init__.py",
+            "sha256": "29d647dd1fb0b1db7845f3bf1246d6d1de0bf7c8daa6c387b777022a04807732",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_base.py",
+            "sha256": "8c5a6209718de91c5736836402657d7075c60a10d39d3ed97b8e6e7426de37ea",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_clients.py",
+            "sha256": "523e2b26636991b8ece0b07caccd0920d1ccb31601687d23981d7e39af12a45e",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_decision.py",
+            "sha256": "ad3472922390ca4ba6ffda099c0e1a15448001f427e2455f24832d14753d41d4",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_dingtalk/__init__.py",
+            "sha256": "0dd8f16ba1d4df29aa1126161878ed48dd330b2d1eefa74d2df1e46d9e8022ef",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel/-dingtalk",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_dingtalk/_card.py",
+            "sha256": "a4d6db11fa61403b1a6afbea0119bcba47036e6652901f3b46e1ef7f696f6bea",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel/-dingtalk",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_dingtalk/_channel.py",
+            "sha256": "d262172f379b4d9559e55bc7edaf1cac7d5c20d8071deefcc21b3ff4d0b8d2a0",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel/-dingtalk",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_dingtalk/_openapi.py",
+            "sha256": "d5d2391449e414e40f553ccfc74f242dc3087fcf069ba425dc3e1ecf043587eb",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel/-dingtalk",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_dingtalk/_tools/__init__.py",
+            "sha256": "8ec149cabb0fc0818a0ff325a14c97655c2e58dd2fef51dd9978560f959d50e4",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel/-dingtalk/-tools",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_dingtalk/_tools/_base.py",
+            "sha256": "ca69e34dd826e8496e952d65d6613492d0233d7faf3b9dcc17d151300816c769",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel/-dingtalk/-tools",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_dingtalk/_tools/_list_conversations.py",
+            "sha256": "9bda7e6367e9509291062ab48d89d3757d4c45fc36fbaae1009b78241236f3b8",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel/-dingtalk/-tools",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_dingtalk/_tools/_list_users.py",
+            "sha256": "03f74d44ed75e64eb7535d1aafd9eaffdd016038caca8fa30f29256be3054fff",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel/-dingtalk/-tools",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_dingtalk/_tools/_send_file.py",
+            "sha256": "9b7f3ba08022b7bd1a8d6ef514b32dcff3d2ae23f4b50de358adfd9b1eb5e34d",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel/-dingtalk/-tools",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_dingtalk/_tools/_send_image.py",
+            "sha256": "870d6c4a7eed323f2314cd80305c79c95f71603f306238e5228b59630ea5eec1",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel/-dingtalk/-tools",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_dingtalk/_tools/_send_message.py",
+            "sha256": "4c94f6f71061b86ea0da4d7fc0729cd08e2609a47b623092731997bcd3eb1fb6",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel/-dingtalk/-tools",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_discord/__init__.py",
+            "sha256": "97bfbcd480c12c3ea198e375dbb9dcb7f7878edf227156537dd92666baef61a4",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel/-discord",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_discord/_channel.py",
+            "sha256": "f8b07b262c9d803e63a98d619e6545e125a88d9a8616c100ac4ab462b194e00f",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel/-discord",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_dispatcher.py",
+            "sha256": "890e2a4376f93a87fdedbd95a0b846888520eb59b63b368e5f7a3f3a509f5735",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_errors.py",
+            "sha256": "11a44c134fb402b8b46fa0ee23e27856f325f8f743bfccbc4888e6e2135835ac",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_feishu/__init__.py",
+            "sha256": "e6db329a2745676010bef12b178d4421ab64c4d84d41d0d18aad714d0b3207f7",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel/-feishu",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_feishu/_card_templates.py",
+            "sha256": "2b23ab3eaa66e599439aefac2080b753169dd9f8ca9e4848f1ef76620d52724b",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel/-feishu",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_feishu/_channel.py",
+            "sha256": "c3212899e4eceb6f646ee2cef1e6031d9548fdd95bab6966766f604b77fab944",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel/-feishu",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_feishu/_tools/__init__.py",
+            "sha256": "91d4c6b8dec9ab0d873d7441583b4e7b1ad9d67eb2b16a03f5b3db43a37dd108",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel/-feishu/-tools",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_feishu/_tools/_base.py",
+            "sha256": "942a1b30abf625f7555b9265eb5aaf780eb4eadb1635eb8a91f71d95b2def968",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel/-feishu/-tools",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_feishu/_tools/_list_chat_members.py",
+            "sha256": "927c1d8486faa7182f9f7b2d200695eee1abe91ab4c08416286f26c86b19161c",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel/-feishu/-tools",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_feishu/_tools/_list_chats.py",
+            "sha256": "cd32b1bb46f7dd44a35d7f9d4a48f44e77ca6fe56d34a53c00ace2d74e04fdd3",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel/-feishu/-tools",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_feishu/_tools/_send_file.py",
+            "sha256": "7ec35e8624ea759ff8373e45e2b3ee192ade90baed73ea3eb52fdc2f4e0be6d9",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel/-feishu/-tools",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_feishu/_tools/_send_image.py",
+            "sha256": "86a47b55ede67946b168e5b0321517fe49174255a683f20b7e44ed19c93fc389",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel/-feishu/-tools",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_feishu/_tools/_send_message.py",
+            "sha256": "256804c16e08990a231b3f8a1f928580ad1b0108ce223b0f1c15dfc33a55b029",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel/-feishu/-tools",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_gateway.py",
+            "sha256": "983da13c1613dffd6d7e82657eb6a9d7c60cb1d9fec3339d2d139e851d850452",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_registry.py",
+            "sha256": "4fa501387778820cfa515a52639e92dfddd5b15d0beab7ce111afc1f51021cbb",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_routing.py",
+            "sha256": "201855241f741a2dbe4727cf6f8a8b34ab5ad5439a6d153f0e64769e5494db02",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/_stream.py",
+            "sha256": "e38fde4bc4cdb88f7ccbee9d233c04ba310e553563098fac11b955bc649626a5",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/channel/worker/__init__.py",
+            "sha256": "69ba5eea7345696db689908c4da01b0b0ce4d39550accac806fe4a1058add739",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/channel/worker",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/deps.py",
+            "sha256": "611fce28b960a133321fb03f9c0feff01848b03e2f2e43c49a9c72879abbc8bb",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/hub/__init__.py",
+            "sha256": "bd24a7b5d3e1a41428351a3ab0329a5d85ea4ac61e769f8183642192024be3e3",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/hub",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/hub/_base.py",
+            "sha256": "0f7d32860b72fcb152c9dd6d362c729684957a92d9cb67e83b95702d813b01f9",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/hub",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/hub/_error.py",
+            "sha256": "46b9921caf22aff32df03659b52c3487d56894bb2318a94c5f0c44772db5631c",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/hub",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/hub/_mcp/__init__.py",
+            "sha256": "1602c30f3caaf55690361c920c04c7f2ef95332a5e5479b808d49aa4629d7916",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/hub/-mcp",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/hub/_mcp/_base.py",
+            "sha256": "516ee88dbb537bad4f5f580af749f3ad5b08b01e6a818783cd419740060a334d",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/hub/-mcp",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/hub/_mcp/_card.py",
+            "sha256": "9cd788c8231c1cc2dc1e47e4a1070dfc1b93ace4e72a049e98528e30403c518b",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/hub/-mcp",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/hub/_mcp/_github_hub.py",
+            "sha256": "f222e138178a4e3b418b0bee20184062b555a736eb745104e7134eefce13e419",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/hub/-mcp",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/hub/_skill/__init__.py",
+            "sha256": "64fd336b0f5893346538e5ab7f8ee9388c8445dce7643e2830e372766ebd6ba9",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/hub/-skill",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/hub/_skill/_base.py",
+            "sha256": "2b7d28860a71029ad092099a51b6c4a6af4849d0bfcbe1fd2d17a3a643588928",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/hub/-skill",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/hub/_skill/_card.py",
+            "sha256": "6ca215b5a10896a00aa28415fd9b603a5ff47a8c8e21732768c1107c5b3d8061",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/hub/-skill",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/hub/_skill/_claw_hub.py",
+            "sha256": "6d4dd8d9227774cd2023c54b29260724397b528653f029198f8b4ef18dd30621",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/hub/-skill",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/message_bus/__init__.py",
+            "sha256": "9302b96c964fafea9beecf88c0401e7e192d8348dac3b70d057e66e13137aaee",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/message-bus",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/message_bus/_base.py",
+            "sha256": "cfa514b93f2a107108adc5b02fe3c684f9a29c6df412eff20fd718dddd0a0c9a",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/message-bus",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/message_bus/_in_memory_message_bus.py",
+            "sha256": "676d8f6deee838338e121e692620bd501e8f8467d2d0947e28d0b335d5c93358",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/message-bus",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/message_bus/_keys.py",
+            "sha256": "7f48c3fff0523817b55f1a909f1e72502c1537469fd7a88ff38c6739c7a308ec",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/message-bus",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/message_bus/_redis_message_bus.py",
+            "sha256": "c441625b40b886f39c803ee5543da0af0de82b6d728de0e290345d6b07c900d9",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/message-bus",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/middleware/__init__.py",
+            "sha256": "1d5003e5d018083affef054c42f67c7f319648ed3d6913fbbd5d34b67912116e",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/middleware/_inbox_middleware.py",
+            "sha256": "9bd46f6d58650833f482d678868feb852b1d561130caedb38f3fba351c5595be",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/middleware/_protocol/__init__.py",
+            "sha256": "3b9d7f4579a5a3a8e2835dac642b5a564a130adbaa1ac8a1235990b7b6033fb3",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/middleware/-protocol",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/middleware/_protocol/_agui.py",
+            "sha256": "11e314155359d6ce6036d83c1cb2d77cad9e5238f22143dafe479c1cb3562f2f",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/middleware/-protocol",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/middleware/_protocol/_base.py",
+            "sha256": "512c0ae34d6f7b7ecae8a6f491988ef5bd81f357fdb82d5e3055a2b818e8370a",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/middleware/-protocol",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/middleware/_state_change_middleware.py",
+            "sha256": "9ea026e8756a9204ef28910e6cb43d08516e4ae6cac8ba4bcf2fc6ff2b3f52ac",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/middleware/_team_member_middleware.py",
+            "sha256": "20100a1f8ca345d914b332ee83cb3b28c90b42d0c8cfd938508aaf791e923e0e",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/middleware/_tool_offload_middleware.py",
+            "sha256": "0368b208668569650211fa439c320aed3427098dcc179346488c91bae856cfa8",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/rag/__init__.py",
+            "sha256": "3bad39ce3a162a1168267a0bdca0cae28f4a8c2853b9ba11f5e90f32458ff000",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/rag",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/rag/blob_store/__init__.py",
+            "sha256": "ec46a5aa105f6f0a0ee5559968aded3f97100265f7cd1e2ffa80887d16ccda0b",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/rag/blob-store",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/rag/blob_store/_base.py",
+            "sha256": "38d9fd8530b75bc132a1a1a4e75d3649680bdcc25144b7c0b6c526993fc88394",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/rag/blob-store",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/rag/blob_store/_local.py",
+            "sha256": "ed3764ba5c662840227c41ac2fa202826f6b0cbc9192a2749c30a3db61909fe2",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/rag/blob-store",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/rag/blob_store/_s3.py",
+            "sha256": "ea3d154362303e7965d1a61dc7ac28094f8d2827df126f60f73d8ac7183a3945",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/rag/blob-store",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/rag/index_worker/__init__.py",
+            "sha256": "82cdc36676e5bbb53990ded689141f31bcaf887e9b04f224bbe417b0cbeab65b",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/rag/index-worker",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/rag/index_worker/__main__.py",
+            "sha256": "1d671116698b7be02f04e74142aefe0bf4b36f6955f2c17ad2c569624a1c7214",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/rag/index-worker",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/rag/knowledge_base_manager/__init__.py",
+            "sha256": "f20dedaace90784ac5c71098ea8d969e46ebf2241f63650962267209080950d5",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/rag/knowledge-base-manager",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/rag/knowledge_base_manager/_base.py",
+            "sha256": "f1e0e95bbb283c8e0e2d77f1cb3f4872125e3711f4c64173df0b91e7abea2c03",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/rag/knowledge-base-manager",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/rag/knowledge_base_manager/_collection_per_kb.py",
+            "sha256": "5f05b3238864a0be62a8546954840c3ee9b9d5bf11edc58599559ba29f1e99c9",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/rag/knowledge-base-manager",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/rag/knowledge_base_manager/_dimension_policy.py",
+            "sha256": "ec75348e3f7fac960cd5f8c3b3f0b2dacb22a29cb7053bbfb61cdc5cc8e33d24",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/rag/knowledge-base-manager",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/rag/knowledge_base_manager/_errors.py",
+            "sha256": "d37d9a514127bf6a803b16abc28b048f8795c0a95cad9e4b82f1304a989768cd",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/rag/knowledge-base-manager",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/__init__.py",
+            "sha256": "208fb9221b65bdc23415f384228868ec1102bb2f4613c8a68c8e84917c0c3bd8",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_base.py",
+            "sha256": "6d6800ea0b742cef5f44e2c40dad89ad3ef20465a7c78c36bcd3947b630f2c75",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_model/__init__.py",
+            "sha256": "cb3f9e8145c5f3ddce5952f0845a0644a413f8e2b1a5037ab761ab27e461e0ba",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage/-model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_model/_agent.py",
+            "sha256": "fa5869964d2818b5fcdaec04f9519d721f0103e9b963a95385c1becce3b5969c",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage/-model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_model/_base.py",
+            "sha256": "5f10cd01c81a818474688e72366765befe9cdd806d7a5da40131bef8f0e41354",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage/-model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_model/_channel.py",
+            "sha256": "1b5271716bb129c8dfe74e49558e2fb477b7981a9b62604789aaff453fa22df6",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage/-model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_model/_credential.py",
+            "sha256": "b67b40d9e859182d8476cf7bea3029030ee753beef6d5f989c9a1a24ac795758",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage/-model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_model/_knowledge_base.py",
+            "sha256": "f666d246e875e911693973b2ae27d5181fe57c19c663ee71dc6a3235a34e9054",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage/-model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_model/_knowledge_document.py",
+            "sha256": "56b01e95cea36438b05111e86670cb55e039c2e00737cd6b9d5d02dc609229cc",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage/-model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_model/_mcp.py",
+            "sha256": "a88c48fb7062b1c471670b05cc8a1b9d6af14d4b79e57f9701ed630a0e07d04d",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage/-model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_model/_schedule.py",
+            "sha256": "7ac5386d93c13244046880c6d65ee7fbccbb2e82cce53c3485b63fd1cd475c05",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage/-model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_model/_session.py",
+            "sha256": "bed8fe4abb0dfc6640e96be8d6aaf250b2290b35aeb82b3f8ef459acb2f97f5e",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage/-model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_model/_skill.py",
+            "sha256": "fd3db6c76c860fec9d5dcfb72a884bd35b402e816932d9f186296716f17acabf",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage/-model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_model/_team.py",
+            "sha256": "02ac852e2d5af1039bb0d731ac2aa5e1db65b6ee7a823629eeeff371a55c8d6c",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage/-model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_model/_user.py",
+            "sha256": "4b99e06a6699bbd6fef97ae8af242cdc9fba5e3cf629ff10e92f8be20d6a0b60",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage/-model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_redis_storage.py",
+            "sha256": "20e92b1b1d7f104950598f4b65084afc0be3d79c3c0420387c18cc4c4a459352",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_sql/__init__.py",
+            "sha256": "8728c1c30792159431e32b016907d9d5424104eaee181cd375a48e55bb674aa0",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage/-sql",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_sql/_alembic/alembic.ini",
+            "sha256": "053ddc524dd4be3b7ab1cfff6eb0e29d70680a81cd385d8ad3416fab4cedac04",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage/-sql/-alembic",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_sql/_alembic/env.py",
+            "sha256": "f47a4e81e9777aa631ec5a0f360d792f162c0f412825ac48c2f4761a52e090c7",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage/-sql/-alembic",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_sql/_alembic/script.py.mako",
+            "sha256": "d21f04abd7a689f5af6f8c8ea468dbb6ea9f78b030b496578e65545f986845dc",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage/-sql/-alembic",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_sql/_alembic/versions/0001_initial.py",
+            "sha256": "74a0c5d20908f93520976954c728014177f434740220484c4d1279052ad173dc",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage/-sql/-alembic/versions",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_sql/_alembic/versions/0002_mcps_skills.py",
+            "sha256": "9fc64ed27299dc2794e51b823fe81b84ffbf66ebc1d0b4aaabf5b02cd469ad3e",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage/-sql/-alembic/versions",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_sql/_alembic/versions/0003_channels.py",
+            "sha256": "37938fe72296baa8cd5942492cc940ec407ad63bc218a739c49e21f7ab9fed2e",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage/-sql/-alembic/versions",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_sql/_mappers.py",
+            "sha256": "febbd4eb5e40eabbdf0ab9b3f46a13f5ac8cc9334cc3969ee7bff61e82563f94",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage/-sql",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_sql/_storage.py",
+            "sha256": "9e83cd7012a56bb80abe3adc6ea2d2d994e56a1583e067eb252c406f1003aec8",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage/-sql",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_sql/_tables.py",
+            "sha256": "780a9c940a4682089abe9a9853163402383135c3859bbfe893411ddfcb57caa4",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage/-sql",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/storage/_utils.py",
+            "sha256": "3e8f724b749b9e7fae7826ccbdb68930a847ef655d25fff7e6dec976362c1b10",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/storage",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/workspace_manager/__init__.py",
+            "sha256": "edcfb98ae1bed7a8bbb4436de9599a9ddb2954458475fba32b0eae4bba97c7ff",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/workspace-manager",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/workspace_manager/_applecontainer_workspace_manager.py",
+            "sha256": "325ea59912e61c2d46e3a9642e08a85bfc2e91ea5e8b5c6195c8699cb5234765",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/workspace-manager",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/workspace_manager/_base.py",
+            "sha256": "261e00a36903e3d441b66dbe24c261a1d8b5263e5aa089b3676ddb206cddadf5",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/workspace-manager",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/workspace_manager/_bubblewrap_workspace_manager.py",
+            "sha256": "f17c64e86c9b15bc2f1778c5eda42559ba58385ca9dbf5c8f4986d0d523336cc",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/workspace-manager",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/workspace_manager/_daytona_workspace_manager.py",
+            "sha256": "671e985086cee21c02df8a8e7f7073097add330f8031ae710da2d3c800e95890",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/workspace-manager",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/workspace_manager/_docker_workspace_manager.py",
+            "sha256": "70d05aa5bdd962ba9e00d987f0be17d6e58cbcb9eecf70551cedbbf409655d69",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/workspace-manager",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/workspace_manager/_e2b_workspace_manager.py",
+            "sha256": "90a70a722721b2c8d12a4610eb8a69991e27905f243c37c16183b524725810a5",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/workspace-manager",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/workspace_manager/_k8s_workspace_manager.py",
+            "sha256": "c938c194232f98ac83f60fe600cc2ef9fd615de1ba16869261cdda402a567f73",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/workspace-manager",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/workspace_manager/_local_workspace_manager.py",
+            "sha256": "e68eb8a7cea4916e7e328442adcd9ac9b9a45d59aa57524dac8e4ba0b1c339a1",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/workspace-manager",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/workspace_manager/_opensandbox_workspace_manager.py",
+            "sha256": "4c4b066e637d709b7ea2599764ff23378092ba0a94d81dd317edf09c1d6ca457",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/workspace-manager",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/app/workspace_manager/_prewarm.py",
+            "sha256": "e77be7bd4779997f06dcd6255d106be86be2db1b2cb867e3d9d977ad3acaa81b",
+            "module": "app",
+            "typescriptTarget": "packages/agentscope-service/src/workspace-manager",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/console/__init__.py",
+            "sha256": "bdcb2cf780fa44c12718c9bbbf664fad0f42d299f7e3a179083f53896215cb1b",
+            "module": "console",
+            "typescriptTarget": "packages/agentscope/src/console",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/console/_console.py",
+            "sha256": "3dc76e44304ec82af05dfd359548fd2c799426ce5551bd20afb7cdadb81e09eb",
+            "module": "console",
+            "typescriptTarget": "packages/agentscope/src/console",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/console/_renderer.py",
+            "sha256": "fbb5890d6e51b4e4182b4857dff74f80e3af9717478b1d5686d0ac9bb1490d63",
+            "module": "console",
+            "typescriptTarget": "packages/agentscope/src/console",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/credential/__init__.py",
+            "sha256": "5ac05dc808bd380194336c6115625d59d357d1d52abaf7a6ca6f01170a3031aa",
+            "module": "credential",
+            "typescriptTarget": "packages/agentscope/src/credential",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/credential/_anthropic.py",
+            "sha256": "ab9d13afbd87a34ff3d09f777f9b13a5ef17fbf2744530276627ab4ad6a3d6a0",
+            "module": "credential",
+            "typescriptTarget": "packages/agentscope/src/credential",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/credential/_base.py",
+            "sha256": "6d8ab896eb13ef837c6dc602af8ee8790817a04f1b62c04ff210aa6e17b3d5b5",
+            "module": "credential",
+            "typescriptTarget": "packages/agentscope/src/credential",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/credential/_dashscope.py",
+            "sha256": "8558744f015b5fb9c945b79d320c27cce5a00e620b59661391003768daf12ce9",
+            "module": "credential",
+            "typescriptTarget": "packages/agentscope/src/credential",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/credential/_deepseek.py",
+            "sha256": "ebbce76b8bd134e95ce6c810c992d3629cc8c252b8fa2c00dbf4346b89e52ddd",
+            "module": "credential",
+            "typescriptTarget": "packages/agentscope/src/credential",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/credential/_factory.py",
+            "sha256": "d31dd13cfb5ed636b37ffc36b215525f70bbd2fe0521170adae20f40b95be85e",
+            "module": "credential",
+            "typescriptTarget": "packages/agentscope/src/credential",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/credential/_gemini.py",
+            "sha256": "b5ac1b5578ec8121ecec3fa0f0c6b40812a748355b7fd44fd8049b9de2a603c1",
+            "module": "credential",
+            "typescriptTarget": "packages/agentscope/src/credential",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/credential/_kimi.py",
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "module": "credential",
+            "typescriptTarget": "packages/agentscope/src/credential",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/credential/_moonshot.py",
+            "sha256": "ae5ba41e54ff049fa8469c37f605b6b15c383052595b8a628ac86c9c30abdf5b",
+            "module": "credential",
+            "typescriptTarget": "packages/agentscope/src/credential",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/credential/_ollama.py",
+            "sha256": "97b4f7143e86c1b2a00df44de42468bb0968ba8555a5e0fa2ca7937a282548bb",
+            "module": "credential",
+            "typescriptTarget": "packages/agentscope/src/credential",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/credential/_openai.py",
+            "sha256": "98c373b954b3c33cbaa2c4b8f6d94ddb2635c35159d8c4e4701aee7c9e246e0b",
+            "module": "credential",
+            "typescriptTarget": "packages/agentscope/src/credential",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/credential/_xai.py",
+            "sha256": "4ae266c49fd84bf384ef7e66b96b3f398e3e97dcd59eb264bda5c1f1a51edf67",
+            "module": "credential",
+            "typescriptTarget": "packages/agentscope/src/credential",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/embedding/__init__.py",
+            "sha256": "0a42bdbf36009ea2a372dda8df87ed3de06d5b99bb05d0d7ee2aeb75644caea0",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/embedding/_cache_base.py",
+            "sha256": "415fc3f50d516edb6cd41a68ac9568985c1a2f21ba9eccbd1b184b40dc61e256",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/embedding/_dashscope/__init__.py",
+            "sha256": "b68c51e70d21604a8adb5ced06e4e901b2e069162d379a71fdd1f603e00c8a5d",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/embedding/_dashscope/_model.py",
+            "sha256": "6dbfd98e6053e00cca17c1d7a802ff78bad7eb66e55d8d98172b6f55dd22b697",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/embedding/_embedding_base.py",
+            "sha256": "bca7deea15727dd197faadc9104af5ddd791b35f248e6e7327fe5f6ec1e2efac",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/embedding/_embedding_model_card.py",
+            "sha256": "53a12d18ef5d49279729ada67d97e11973f84aabcb6161d517caf268faa5f1e2",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/embedding/_embedding_response.py",
+            "sha256": "9da12a95ec27e89e54cad7817b0c249c7e87959553a3649184def5e0984e9365",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/embedding/_embedding_usage.py",
+            "sha256": "675ab9c8f5ee191f01a41ef2531727faf3df9913fb82a9c69818ec4860b67f5c",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/embedding/_file_cache.py",
+            "sha256": "d8c6698aeadc560aa409322ad94ffc6749ff0f423567cee8c176342be16a7ef9",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/embedding/_gemini/__init__.py",
+            "sha256": "7e84c1e27e3bee156d16f682c1dcf4bbda65337d808cfd66dbe6abd02258e6f7",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/embedding/_gemini/_model.py",
+            "sha256": "85d2c2c38ff465c3ceff40d7845a23f2a47d6caccffadfd2e5dc81d71f3d2733",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/embedding/_ollama/__init__.py",
+            "sha256": "c15d80c808ed2f66b860e0e55268350f164ba96d30f9734840a6e28188ddaaaa",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/embedding/_ollama/_model.py",
+            "sha256": "af976e40b4f82076b077a66f25aa89c0532dd3d79900adf56d142fa3c77cde65",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/embedding/_openai/__init__.py",
+            "sha256": "34ab2f8ac004640a0f25e0e18f25a56cfbc7c5f109a76ada0ae41847bcd848ba",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/embedding/_openai/_model.py",
+            "sha256": "9cb1d68042c294b232c9ad8792d07602b68df7d001a18fc5d53f5a7f7d0a950d",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/event/__init__.py",
+            "sha256": "3fb188eb476458e0a2b5fb8185935d824233d673cd4147a3fe8db12f316545aa",
+            "module": "event",
+            "typescriptTarget": "packages/agentscope/src/event",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/event/_event.py",
+            "sha256": "685e8353257db5ec4fdc0db97c513fbb4115143edecc868d6429712479f1c0d6",
+            "module": "event",
+            "typescriptTarget": "packages/agentscope/src/event",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/exception/__init__.py",
+            "sha256": "673c4db6959111c30cefce253c5b43948273ac15f15ba0c4591afc3ae1561104",
+            "module": "exception",
+            "typescriptTarget": "packages/agentscope/src/exception",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/exception/_base.py",
+            "sha256": "8311702c53fbc011f9430fffe85bdd314e26f145da9637696019770bc4e1c841",
+            "module": "exception",
+            "typescriptTarget": "packages/agentscope/src/exception",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/exception/_model.py",
+            "sha256": "33067d34d3073ecb077189e12c3344a0a292a01703ad614ee274100edeaa4f04",
+            "module": "exception",
+            "typescriptTarget": "packages/agentscope/src/exception",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/exception/_tool.py",
+            "sha256": "243762e6e1e95fac19e4c864094ed4312220841f21a63d98396b87f759c781f2",
+            "module": "exception",
+            "typescriptTarget": "packages/agentscope/src/exception",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/formatter/__init__.py",
+            "sha256": "f3aadfed7a8b39bb4be5f0376b98b9ffe48fad092049a60ef64fbc68455b08f0",
+            "module": "formatter",
+            "typescriptTarget": "packages/agentscope/src/formatter",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/formatter/_anthropic_formatter.py",
+            "sha256": "f75b17c2de7475177a272c3923c774f882de314cd4ef67b65eecc8ad662a4db1",
+            "module": "formatter",
+            "typescriptTarget": "packages/agentscope/src/formatter",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/formatter/_dashscope_formatter.py",
+            "sha256": "5a924531f06c22fd7dbbc30d0302c33c1a1c10cb68aa6a87cfb0cdecadad2210",
+            "module": "formatter",
+            "typescriptTarget": "packages/agentscope/src/formatter",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/formatter/_deepseek_formatter.py",
+            "sha256": "1fd6ae76f6c7ec3436629e51c306bbf9cb6951ddec9c2660e3acd014e0b0d82a",
+            "module": "formatter",
+            "typescriptTarget": "packages/agentscope/src/formatter",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/formatter/_formatter_base.py",
+            "sha256": "08f204bff43ffca518cae88423a794f295dcbeca0e3c4090aa8b24407559521b",
+            "module": "formatter",
+            "typescriptTarget": "packages/agentscope/src/formatter",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/formatter/_gemini_formatter.py",
+            "sha256": "4edc11d2dc28f7b5e4e5564ba9dfe183edeef122219381c2e7aadbf6e72f7667",
+            "module": "formatter",
+            "typescriptTarget": "packages/agentscope/src/formatter",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/formatter/_moonshot_formatter.py",
+            "sha256": "79c2969e27820621c0dd0a070582f33b43d2a8e19de86bb9df2eee78a9e05198",
+            "module": "formatter",
+            "typescriptTarget": "packages/agentscope/src/formatter",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/formatter/_ollama_formatter.py",
+            "sha256": "3aa0b6967726d064ad8b2bbf0541509b5250244a5280ad788b89f75cd489d783",
+            "module": "formatter",
+            "typescriptTarget": "packages/agentscope/src/formatter",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/formatter/_openai_formatter.py",
+            "sha256": "959163bf8aee648c2b8bdf1562a1b5c2f93d78b96b7a3aef190695e729980143",
+            "module": "formatter",
+            "typescriptTarget": "packages/agentscope/src/formatter",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/formatter/_openai_response_formatter.py",
+            "sha256": "586e2c9a917b72454171d63c47b50d1f7ea5c720c7125418af7fc5599845442e",
+            "module": "formatter",
+            "typescriptTarget": "packages/agentscope/src/formatter",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/formatter/_xai_formatter.py",
+            "sha256": "f87addddd3c272d3e3df0d06b8cdc20104b5ea278e7fd6124425140c20061ebb",
+            "module": "formatter",
+            "typescriptTarget": "packages/agentscope/src/formatter",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/mcp/__init__.py",
+            "sha256": "7b3c2c9bf70e7cbb0b1a278ec033ef0b076c2cd7348bba61157545a589f8e2b5",
+            "module": "mcp",
+            "typescriptTarget": "packages/agentscope/src/mcp",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/mcp/_config.py",
+            "sha256": "6811c8987796f73e42850fa9897c927d8ec721be86d97efb9d891662f9a1f3b6",
+            "module": "mcp",
+            "typescriptTarget": "packages/agentscope/src/mcp",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/mcp/_mcp_client.py",
+            "sha256": "d9c0760b3412e9b9c8fac53e557e57961331e9c2b1f5f953df5598c03021fdaf",
+            "module": "mcp",
+            "typescriptTarget": "packages/agentscope/src/mcp",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/message/__init__.py",
+            "sha256": "2cd8f567bb80b3c187aa97545f3a6ee21d5c2c1b9842dfc74997288c9005f5b8",
+            "module": "message",
+            "typescriptTarget": "packages/agentscope/src/message",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/message/_base.py",
+            "sha256": "7c94d632b975cc61315b46fd8798e683d6ba939c888fb686261947070f803c07",
+            "module": "message",
+            "typescriptTarget": "packages/agentscope/src/message",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/message/_block.py",
+            "sha256": "befd7027725275b041e758c2ce6c2250df1eede8b028ad3161d9df0a97b79d3a",
+            "module": "message",
+            "typescriptTarget": "packages/agentscope/src/message",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/middleware/__init__.py",
+            "sha256": "b9c69aeca8ea7cc49ae105726d5f1feb509ee503cfdf97ab253dfe612ffca8e3",
+            "module": "middleware",
+            "typescriptTarget": "packages/agentscope/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/middleware/_base.py",
+            "sha256": "e459260c4e8a460c8f085f2a4f3a136e97019105919736a1f83ebb9b1e5ec993",
+            "module": "middleware",
+            "typescriptTarget": "packages/agentscope/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/middleware/_budget.py",
+            "sha256": "3271f55b82af499dc37207eb81c4f4b44d9dc236fedca16b11eb7c54f39f8caf",
+            "module": "middleware",
+            "typescriptTarget": "packages/agentscope/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/middleware/_longterm_memory/__init__.py",
+            "sha256": "3ede5df548ce58264f6efe7d3ad65b15d0dde93965213af0413d5e9d0e7e6b53",
+            "module": "middleware",
+            "typescriptTarget": "packages/agentscope/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/middleware/_longterm_memory/_agentic_memory/__init__.py",
+            "sha256": "aaa1a3932eeafc81cc56273753f7b48aab0675bc8f4dc2f47a7b487ce59fbd1a",
+            "module": "middleware",
+            "typescriptTarget": "packages/agentscope/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/middleware/_longterm_memory/_agentic_memory/_middleware.py",
+            "sha256": "687f8e15433671b3291dc3b8d6da5bccf02b3aada56bee444598a754e916ea20",
+            "module": "middleware",
+            "typescriptTarget": "packages/agentscope/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/middleware/_longterm_memory/_mem0/__init__.py",
+            "sha256": "c95ecb6525b9207a739764704b4bbbd05a11b49b20ad39401b4988348c9db8d3",
+            "module": "middleware",
+            "typescriptTarget": "packages/agentscope/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/middleware/_longterm_memory/_mem0/_agentscope_adapter.py",
+            "sha256": "1313c337bfeb6ad19793af04032e4473eb2d4ef1ae8fac066e0696d640a9715d",
+            "module": "middleware",
+            "typescriptTarget": "packages/agentscope/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/middleware/_longterm_memory/_mem0/_middleware.py",
+            "sha256": "28215eb51febd6519ade351e1fad5b38d88e0d08b0608fb5ee5abb62081a9bfe",
+            "module": "middleware",
+            "typescriptTarget": "packages/agentscope/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/middleware/_longterm_memory/_mem0/_tools.py",
+            "sha256": "39723c64f5e69988895555133603a71d1e6d65ba41f64843467113f74a665ce6",
+            "module": "middleware",
+            "typescriptTarget": "packages/agentscope/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/middleware/_longterm_memory/_mem0/_utils.py",
+            "sha256": "a4e8a2d61d22ae1c0d0698a9a712ec839844f9a79356e296ef266b09b752dac8",
+            "module": "middleware",
+            "typescriptTarget": "packages/agentscope/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/middleware/_longterm_memory/_reme/__init__.py",
+            "sha256": "c835bc9d99c34b59bcfb874747f831460f6515b0cfd6803ca23abb659920983d",
+            "module": "middleware",
+            "typescriptTarget": "packages/agentscope/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/middleware/_longterm_memory/_reme/_config.py",
+            "sha256": "8a9e647fde27a15cb5bb06309e55304b30681ff61e92847d7cc20ce8424c04eb",
+            "module": "middleware",
+            "typescriptTarget": "packages/agentscope/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/middleware/_longterm_memory/_reme/_middleware.py",
+            "sha256": "551470db3036043988b755193a505c11d196cb534a949396631eabc4b204da98",
+            "module": "middleware",
+            "typescriptTarget": "packages/agentscope/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/middleware/_longterm_memory/_reme/_tools.py",
+            "sha256": "133ccc5157168d44ccddbe2dd2e6fd8d0d1b542792d0eba6bcf927bb5b087d76",
+            "module": "middleware",
+            "typescriptTarget": "packages/agentscope/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/middleware/_longterm_memory/_reme/_utils.py",
+            "sha256": "f63109f3955cf4c6dc777f3b0062e9a7a6d104fdc3407bb7be6bbcbc0d1aaf4a",
+            "module": "middleware",
+            "typescriptTarget": "packages/agentscope/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/middleware/_rag.py",
+            "sha256": "1dcb6ab05686f92811a6057b42456d3343549b2229529f4e5fb8086c80151d58",
+            "module": "middleware",
+            "typescriptTarget": "packages/agentscope/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/middleware/_tracing/__init__.py",
+            "sha256": "0ce43a1fd32b3641e64f4c9845dbc7b58fa3a98b4072dd1172f079f7a3beb9a7",
+            "module": "middleware",
+            "typescriptTarget": "packages/agentscope/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/middleware/_tracing/_attributes.py",
+            "sha256": "364a3ebb7dc3b356c64998ae9c772099ec282c6de402e69ed697c08585d78079",
+            "module": "middleware",
+            "typescriptTarget": "packages/agentscope/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/middleware/_tracing/_converter.py",
+            "sha256": "beed9a56815a02595b1e610d46ee3c20e680f489442efdac5e58c962031f6455",
+            "module": "middleware",
+            "typescriptTarget": "packages/agentscope/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/middleware/_tracing/_extractor.py",
+            "sha256": "0dc118769752c5b2298fbe11533d9a752d0f25a77022dfc1d4fa1ccff3f93aa6",
+            "module": "middleware",
+            "typescriptTarget": "packages/agentscope/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/middleware/_tracing/_setup.py",
+            "sha256": "e73ba09dde8e81f182a26b81cdd18981a6173355b2803ad9a9332b387e705d9f",
+            "module": "middleware",
+            "typescriptTarget": "packages/agentscope/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/middleware/_tracing/_trace.py",
+            "sha256": "7434a4e5d4d7898e36eda3aa70a712e762951c32f765897c1aa42a2ccb7d68ea",
+            "module": "middleware",
+            "typescriptTarget": "packages/agentscope/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/middleware/_tracing/_utils.py",
+            "sha256": "9757b9f994784df0153192894600a9860290dc69330e9e9a99ade0b839024a75",
+            "module": "middleware",
+            "typescriptTarget": "packages/agentscope/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/middleware/_tts_middleware.py",
+            "sha256": "4bee3351b06dfecfcade9292a0e8549b8a00e2a2917c0f2ad5cf17438838331c",
+            "module": "middleware",
+            "typescriptTarget": "packages/agentscope/src/middleware",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/model/__init__.py",
+            "sha256": "e392c58e884f9624e25b81dc716b4ba0b4374ab412e0844241e3063397dfa496",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/model/_anthropic/__init__.py",
+            "sha256": "b2c8d6696f76de252ab7a5c29490c452bef36cf535fa92aef8cf67979a5c7a24",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/model/_anthropic/_model.py",
+            "sha256": "ff9288432764b499723a5065f22a7d4d228d0ea4c6af7e31f634a7fcd20fcbda",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/model/_base.py",
+            "sha256": "6ebd45d3c909884a219a15a4d4b1ecf098d3f2a3e8fcde7f941ff84ef08b79c0",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/model/_dashscope/__init__.py",
+            "sha256": "f7b308d623e0f40ad951a62b6200865dee0370bfc41d9c6bcc7f556f5b409f3a",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/model/_dashscope/_model.py",
+            "sha256": "c636ff3fcdab806a9cb22b3deea00ff4b1cd28907523ce83499be5ade23aef78",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/model/_deepseek/__init__.py",
+            "sha256": "fadfca8584aae8bc4635d40dc66296fa526c4676ae4d675b63fe31ae1186258d",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/model/_deepseek/_model.py",
+            "sha256": "0a46f554613aa65446b4c765cef527fadeee7eee275796b5efec95de8deb5f3a",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/model/_gemini/__init__.py",
+            "sha256": "6914fd06c9111ae1dc65d38edf7a395e453177177400a5dfb67e0aca050f2420",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/model/_gemini/_model.py",
+            "sha256": "116beecf7be3958ad90773e9c6e4faaf02309a5d22741761e3cad23f8185fd8e",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/model/_model_card.py",
+            "sha256": "6fd7ab6634bb09ea605d1071a531c3d6f31083129fb722b6ba904302388f6895",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/model/_model_response.py",
+            "sha256": "5ce67ec4721590f4f773c209acbb51a0a49734c6aa763f2392b701fd81f5f3a0",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/model/_model_usage.py",
+            "sha256": "c7b0c6118d49ff7e7f263ba65c0cb184203d7d7d18e7b1252c1e08d08ad3c224",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/model/_moonshot/__init__.py",
+            "sha256": "07e023652adb7d0f32641046928d9f8d859e35e6b341188b79330d6ac4390977",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/model/_moonshot/_model.py",
+            "sha256": "f208894809b99b0f87ca42b5694f0820fb73dab3c6aafaa3d750af411623a740",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/model/_ollama/__init__.py",
+            "sha256": "4c0a13f93a44b4e775d104529a6eff268deb8717404be086ef7c6fc7673384dc",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/model/_ollama/_model.py",
+            "sha256": "c38a9e663154624deef545416078fdfa5bd7adac0e832670b3b7c3724a061fe9",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/model/_openai_chat/__init__.py",
+            "sha256": "2b7b47be3e189e4a32c2efe64f7238a9165373b139933167fbe88fd58af68f9a",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/model/_openai_chat/_model.py",
+            "sha256": "f2ed338fad1bf343ec6dadc0cd58c0e0b9bafc7a26c96ce7ab4233d90f4ce6f4",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/model/_openai_response/__init__.py",
+            "sha256": "ffffc1448679a8d1e27c1db51beacd96682443876cbd47b82d562d6a481acb36",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/model/_openai_response/_model.py",
+            "sha256": "3c63f90f7f75036afa6e8af86497a5e6ebb6fdec2160bd28840686578250759d",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/model/_utils.py",
+            "sha256": "160228da5d90d861e94214de5acf8263ddacf9cb06b54ba740756b98ea457f3b",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/model/_xai/__init__.py",
+            "sha256": "63ccc2556fcee61b7cbd19dba7be88ef11be0aca909f7eec058b80c0f2178bd5",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/model/_xai/_model.py",
+            "sha256": "8ec0449a608c5f3baaac832373569fb8adbf1cd1d05a7f4044fcdb23214f3909",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/permission/__init__.py",
+            "sha256": "3dc31ced74ccda31d0d2d6cd916253a6b4768fb12820899a02a77777f62d3ba1",
+            "module": "permission",
+            "typescriptTarget": "packages/agentscope/src/permission",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/permission/_context.py",
+            "sha256": "7d1d09dfc6a5ef62a8a75a03d185ddbc1352b5c37b1f5eab73d31989d2ad1bba",
+            "module": "permission",
+            "typescriptTarget": "packages/agentscope/src/permission",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/permission/_decision.py",
+            "sha256": "500de4ea9840ea35c64a701d3df657d2662d23976e573f9ccbb1e8e6d059bfce",
+            "module": "permission",
+            "typescriptTarget": "packages/agentscope/src/permission",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/permission/_engine.py",
+            "sha256": "9142e0ecf173542a197562b802879e4e84491436ec3f17a691e11ebc9a0654c7",
+            "module": "permission",
+            "typescriptTarget": "packages/agentscope/src/permission",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/permission/_rule.py",
+            "sha256": "e52409882d9464c54bfa4f9c56a94bdad2f0a9e32e315ac84b6e3ede35a58bd5",
+            "module": "permission",
+            "typescriptTarget": "packages/agentscope/src/permission",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/permission/_types.py",
+            "sha256": "cdc9d544d600a1b375bd2942eb5ecd3b9b3df91bcf0909007711366cfa40ef3f",
+            "module": "permission",
+            "typescriptTarget": "packages/agentscope/src/permission",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/pipeline/__init__.py",
+            "sha256": "4158c734cac95b32341263160d703bc440de60cac3485e44e0e9c4b581ea7d7c",
+            "module": "pipeline",
+            "typescriptTarget": "packages/agentscope/src/pipeline",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/pipeline/_base.py",
+            "sha256": "fb698a60099fe05eb83bbaeff73f7f4565fcb42fc6ce4f1f76cdbc2553e62b75",
+            "module": "pipeline",
+            "typescriptTarget": "packages/agentscope/src/pipeline",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/pipeline/_goal_pipeline.py",
+            "sha256": "69c05617e38c43884b835838a18c070d1c9a376868f1e90433276f69ec19b405",
+            "module": "pipeline",
+            "typescriptTarget": "packages/agentscope/src/pipeline",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/py.typed",
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "module": "root",
+            "typescriptTarget": "packages/agentscope",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/rag/__init__.py",
+            "sha256": "b1b2dec84b8b483d7b65514d9b7149acec0b49be4d8e943e9bbb43a07ec627b8",
+            "module": "rag",
+            "typescriptTarget": "packages/agentscope/src/rag",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/rag/_chunker/__init__.py",
+            "sha256": "003dfa3ad3ba866755b8078cabc92e3c36803c919f357d3847dbf9623d6771c5",
+            "module": "rag",
+            "typescriptTarget": "packages/agentscope/src/rag",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/rag/_chunker/_approx_token_chunker.py",
+            "sha256": "4210bba827b99788021f31f7de4fe4d7e5037d543f59a7b2b59ea3e9cbe6afad",
+            "module": "rag",
+            "typescriptTarget": "packages/agentscope/src/rag",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/rag/_chunker/_base.py",
+            "sha256": "8c4c7408b06363d4bbc61ee4d07c131bab4cc6b0ef8d7413d3a3ad660ac9ca37",
+            "module": "rag",
+            "typescriptTarget": "packages/agentscope/src/rag",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/rag/_document.py",
+            "sha256": "b0d09fa77ead1ef9429fbe506db65c992581c3a862bfe00e574683bb33c8fd1f",
+            "module": "rag",
+            "typescriptTarget": "packages/agentscope/src/rag",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/rag/_knowledge.py",
+            "sha256": "5d3858c044d6eb632844be70c2944e5b62eb665da66f81bf25c5545df92d2ecb",
+            "module": "rag",
+            "typescriptTarget": "packages/agentscope/src/rag",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/rag/_parser/__init__.py",
+            "sha256": "82264a7178d6ee464d794ace0646643a36054a76e1205bd070f8df3242699016",
+            "module": "rag",
+            "typescriptTarget": "packages/agentscope/src/rag",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/rag/_parser/_base.py",
+            "sha256": "ca02c73e3cb611eec94eb244c2f9262c9b590eba053f6d5957c4d3df16372bd4",
+            "module": "rag",
+            "typescriptTarget": "packages/agentscope/src/rag",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/rag/_parser/_excel.py",
+            "sha256": "66c18117106a0f110ca205a63bd488303d94ca6a636e6ff4b01261a14d517bdd",
+            "module": "rag",
+            "typescriptTarget": "packages/agentscope/src/rag",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/rag/_parser/_image.py",
+            "sha256": "cbe5bf1138c81ca8990d10a345c1c003c8dd051244468d8cfd6442449f7048e4",
+            "module": "rag",
+            "typescriptTarget": "packages/agentscope/src/rag",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/rag/_parser/_pdf.py",
+            "sha256": "3c9e51f99d039030fece7c7636caa99e1dd45504d07f6b3290d10dd97761ea18",
+            "module": "rag",
+            "typescriptTarget": "packages/agentscope/src/rag",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/rag/_parser/_ppt.py",
+            "sha256": "4d7e41b9a44f267c942f1c9687b3a8fc6c258c441ea50ceb56c370cc8c1ab7aa",
+            "module": "rag",
+            "typescriptTarget": "packages/agentscope/src/rag",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/rag/_parser/_text.py",
+            "sha256": "0a78e47eebcd21e8d0297aaeea01b24776a78b992b9dcbe4d42e51bd70b4a434",
+            "module": "rag",
+            "typescriptTarget": "packages/agentscope/src/rag",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/rag/_parser/_utils.py",
+            "sha256": "c4d538f54d939a813d07ba47fbb9049e1d167fba40cb3b5bcb9f9753096d420d",
+            "module": "rag",
+            "typescriptTarget": "packages/agentscope/src/rag",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/rag/_parser/_word.py",
+            "sha256": "4c5bf223586df81a34013122cb3363f4f2def1062514f7a00d293da9e9e66bc3",
+            "module": "rag",
+            "typescriptTarget": "packages/agentscope/src/rag",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/rag/_vdb/__init__.py",
+            "sha256": "3810f616046fc049acbe69e21e64c7a4eba83ae5f9bda058f0c8c81acb6caba4",
+            "module": "rag",
+            "typescriptTarget": "packages/agentscope/src/rag",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/rag/_vdb/_elasticsearch.py",
+            "sha256": "7c45952b8c19848e331babfb0b8ee714b8ed638ddb65f0ef03c524a408e8ef66",
+            "module": "rag",
+            "typescriptTarget": "packages/agentscope/src/rag",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/rag/_vdb/_milvus_lite.py",
+            "sha256": "cb9082f02ed4f538da22f9bc39cdb70b2e359d6f058c6c6e012f1243123a77e8",
+            "module": "rag",
+            "typescriptTarget": "packages/agentscope/src/rag",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/rag/_vdb/_mongodb.py",
+            "sha256": "6e6ef35ac191b0ff404f08088f7c11878b112372c002fe9a7e0a0e2fbb85a387",
+            "module": "rag",
+            "typescriptTarget": "packages/agentscope/src/rag",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/rag/_vdb/_qdrant.py",
+            "sha256": "a745061efe58575ac1e1c40f6a52a901a97fcf3091d8cf862e573e93fd226d17",
+            "module": "rag",
+            "typescriptTarget": "packages/agentscope/src/rag",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/rag/_vdb/_vector_store.py",
+            "sha256": "b976e5e21c32cf7f9805809ffeb5236992cd0ab108b23024da92bc31b8321af7",
+            "module": "rag",
+            "typescriptTarget": "packages/agentscope/src/rag",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/skill/__init__.py",
+            "sha256": "1a2c036ac97543095d8da576a3116513797a36469525bcd8c18a19227cd941ec",
+            "module": "skill",
+            "typescriptTarget": "packages/agentscope/src/skill",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/skill/_base.py",
+            "sha256": "8db4eb6d8ac1fc1fcbc2f0abda0fba42f02564841edb68c58d59f63180e9225d",
+            "module": "skill",
+            "typescriptTarget": "packages/agentscope/src/skill",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/skill/_local_loader.py",
+            "sha256": "4f828d0f510068f9cb43bb28c4d994808b66a91fc1e67d9747355abfa216aaa9",
+            "module": "skill",
+            "typescriptTarget": "packages/agentscope/src/skill",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/state/__init__.py",
+            "sha256": "81ef02f268e8cf9c0e1139a8343875dfeb0af6f3256565243218fc4d8c93cf81",
+            "module": "state",
+            "typescriptTarget": "packages/agentscope/src/state",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/state/_state.py",
+            "sha256": "9932e6447eb4c6152659400e2beef9929ba0e81e48c5b3a94b1f621bb2477e31",
+            "module": "state",
+            "typescriptTarget": "packages/agentscope/src/state",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/state/_task.py",
+            "sha256": "5f496458b085da159c7a30be45886667d674a4fb5334a04a2b9568ea1481ec8e",
+            "module": "state",
+            "typescriptTarget": "packages/agentscope/src/state",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/__init__.py",
+            "sha256": "394000d6574402134df5d0ff83525301e58123ccd7cc4bc0264681f631844b8f",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_adapters.py",
+            "sha256": "6f53f0a399ffc5e5709b4b360e70fa51cbb0134df8502db0ac3b21554ce99dcd",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_base.py",
+            "sha256": "936a7a162b0407ecec68ef715163c9b13fcfa7612cd4fdd4537bb8f961217d43",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_builtin/__init__.py",
+            "sha256": "4a0369a89fdeefea3f2ec7b1533ac3b78c619367700c772d9d17bbd9727ccc34",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_builtin/_backend.py",
+            "sha256": "579081de3a400f022f07b14f3b9608ffec1cc61c3759cfcf270e4506a5a5bc88",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_builtin/_bash_parser.py",
+            "sha256": "e9b7c622cf1b8cffc9ba419868f409b4ef2692f725a6cf13f2f6db9ffc2b955b",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_builtin/_bash.py",
+            "sha256": "96407271b0523f35f89d0a2f4cb94465556cd72adcf3c903a6e010934e8d12d5",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_builtin/_edit.py",
+            "sha256": "cb2031b8f6ea51e70794d16e0fb0507250314405516765c1f61a63b672b5c68d",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_builtin/_glob.py",
+            "sha256": "65d7e9ff0f7f8b562a93e783eee766080c80d7344f45d4261a21ed9ee66fa1bf",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_builtin/_grep.py",
+            "sha256": "124c9e2403089a97de698d69218533589233c4692ebf1e9baab1d754b665326f",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_builtin/_meta.py",
+            "sha256": "4a3329a83c35569a86416764963da35ffdb68c14d1a09d32ef59be6966fdffa9",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_builtin/_powershell.py",
+            "sha256": "3a2054ad4946c8956c9fa807e0a14eb5a8a0bda6eeee00ebcf835a4be9dabc8d",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_builtin/_read.py",
+            "sha256": "f84845117645ea9e8e42128331883e4bcbe44e83d558d3227dfe55666a0797b7",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_builtin/_scripts/__init__.py",
+            "sha256": "1610f0f0fe7a808c678bd486bdb4280535bce873e94d02ca03ca9e99f7a72f07",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_builtin/_scripts/_glob_helper.py",
+            "sha256": "417060a6db71a48bbb11b3848e350a1f26c63af5fb5f41b0574257f93a897a28",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_builtin/_skill.py",
+            "sha256": "66ad7aee59386a14a8f458b0753aae8153b79962be1474248a80f73e21f292e9",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_builtin/_write.py",
+            "sha256": "257d6629df935fc61e34fab32b2fb9cd66616960aee063e0d98991dc1db23bc1",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_constants.py",
+            "sha256": "4a562c4f9590c0b0b846d742666412bd77411594abf0b3aa7ef949b92378f452",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_response.py",
+            "sha256": "a089d3c54b386fcafc159529c633c11fe145ae6171fe5a88ecdf9a94beb491b1",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_task/__init__.py",
+            "sha256": "8109a25985e1143259e70a7a4462a4ca2f8c7f427547f487677755b310948af2",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_task/_create_task.py",
+            "sha256": "f44b48b5e2251d7507b9bb4cd6e68312095753a41f552284858e19847a7f8a80",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_task/_get_task.py",
+            "sha256": "eaa8c73e3deedf99d78f38285816646f432cc236c86100dde71a9115ec58fae5",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_task/_list_task.py",
+            "sha256": "6c6521b98099b9101fb43b403799401e9fb22f13e6f4f68758f5d0b64e3c1337",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_task/_task_tool_base.py",
+            "sha256": "42dc10cdade4ba9f9b24d2481207ba3954b0a6701ca0ca604d2aebb4cf06f172",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_task/_update_task.py",
+            "sha256": "1135dc07b159d7374607050b74e08e4a25c831b14aa350972e9bcd8718f6bf7a",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_tool_group.py",
+            "sha256": "62e647c3ecbfd80354eea7e4ead151b0094cc78b95b3cb0adf0cde830646b592",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_toolkit.py",
+            "sha256": "6dae116e2cfb825020f72feb1dc0c7a6166509510923fdd41a50f42eafe3f4a3",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_types.py",
+            "sha256": "47680ca83008221870d34f7d34be63a3c15515ce7f773433e36738e39ec64659",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tool/_utils.py",
+            "sha256": "07cf203c1ced18ef372657cef3c0ae9df44763f73d3fa9023c4fbf8cc800dc6b",
+            "module": "tool",
+            "typescriptTarget": "packages/agentscope/src/tool",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tts/__init__.py",
+            "sha256": "12ab96eb14a2e064f5be4fffdf2d459135aa5047647324ab1c84ffaad18d6cd3",
+            "module": "tts",
+            "typescriptTarget": "packages/agentscope/src/tts",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tts/_dashscope/__init__.py",
+            "sha256": "7e403f554100e09901bae417f2fd530c86bc4518e0f0038090b8b91775ae8c72",
+            "module": "tts",
+            "typescriptTarget": "packages/agentscope/src/tts",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tts/_dashscope/_cosyvoice_model.py",
+            "sha256": "1f23b171e828b4b133e2d4ed6d13d78124a0658aaff65085b7ff9a7911c29d16",
+            "module": "tts",
+            "typescriptTarget": "packages/agentscope/src/tts",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tts/_dashscope/_cosyvoice_utils.py",
+            "sha256": "ae6aafb6c32de1fd0ba6f10077d74155e489a04a8d473812658fb96e87ee07d0",
+            "module": "tts",
+            "typescriptTarget": "packages/agentscope/src/tts",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tts/_dashscope/_model.py",
+            "sha256": "f7906270c030bb2517f42cb54d54f805d00a11a3fe340a8a501da86d589cec2a",
+            "module": "tts",
+            "typescriptTarget": "packages/agentscope/src/tts",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tts/_dashscope/_realtime_model.py",
+            "sha256": "06384861223c8112c48f6241d11c6a90a50afe01130b2e20bb3e4cc406131ab8",
+            "module": "tts",
+            "typescriptTarget": "packages/agentscope/src/tts",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tts/_gemini/__init__.py",
+            "sha256": "cbc5390840bd8fa9173c3d72b562cd6541524ea6c5814a42b68f1a575c30a637",
+            "module": "tts",
+            "typescriptTarget": "packages/agentscope/src/tts",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tts/_gemini/_model.py",
+            "sha256": "0782bfcb0e667935e7f6aab30964e3d5a972a84eee459e7a860fbf7b66287f67",
+            "module": "tts",
+            "typescriptTarget": "packages/agentscope/src/tts",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tts/_openai/__init__.py",
+            "sha256": "306e645f53482114d3fd29a3181b4e36b9a7877b98c5de17076cddd2c94fff68",
+            "module": "tts",
+            "typescriptTarget": "packages/agentscope/src/tts",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tts/_openai/_model.py",
+            "sha256": "292f8466f4c3a28f10b5830e030fb16cf07ef769d50e9683e896b5d1a097b7f9",
+            "module": "tts",
+            "typescriptTarget": "packages/agentscope/src/tts",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tts/_tts_base.py",
+            "sha256": "6d6409eb57b40c2d96eea989b8b5d4500178bd5a6daec3b48cad29855dd89870",
+            "module": "tts",
+            "typescriptTarget": "packages/agentscope/src/tts",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tts/_tts_model_card.py",
+            "sha256": "64d50883402b1046f2031679c7395f1954fa126f67cc79fa53f812787faa23fe",
+            "module": "tts",
+            "typescriptTarget": "packages/agentscope/src/tts",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/tts/_tts_response.py",
+            "sha256": "89ca02eff87c09f8de95e7d372ad13f3cce37001191b2430d026db3c32587540",
+            "module": "tts",
+            "typescriptTarget": "packages/agentscope/src/tts",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/types/__init__.py",
+            "sha256": "8bb4b3d9add429c2fffb417b9831c178861aa41a385ddec753b426d829b5d06b",
+            "module": "types",
+            "typescriptTarget": "packages/agentscope/src/types",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/types/_hook.py",
+            "sha256": "b2dfbeda8055b8bc0d68d9390d05e4600ef1a7c5f81daa936977f69550c03ccd",
+            "module": "types",
+            "typescriptTarget": "packages/agentscope/src/types",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/types/_json.py",
+            "sha256": "cb6d7fd2a5f7e9900b9d4722e32505456040dddcebcd29644b57a979c47f780e",
+            "module": "types",
+            "typescriptTarget": "packages/agentscope/src/types",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/types/_object.py",
+            "sha256": "74747ce2626f0457ac6d88f8ea640ef6cb30dfc74fb8aa496826f24a9acb5991",
+            "module": "types",
+            "typescriptTarget": "packages/agentscope/src/types",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/types/_reply.py",
+            "sha256": "9aba4d633ad58def6bbbb5058e94404aff21d4e7947dea80289bebf81f626c64",
+            "module": "types",
+            "typescriptTarget": "packages/agentscope/src/types",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/__init__.py",
+            "sha256": "0e7ee74fc9e416e791be6ae5b8f0347021f0f10f3ab0e86980be36de83404615",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_applecontainer/__init__.py",
+            "sha256": "02e597c826bc6e596c803af50eb2852f0e12b2aba7154a316aa098ff2c0dfc23",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_applecontainer/_applecontainer_backend.py",
+            "sha256": "1b8f2dc1fa633e318908ee58e10ee4635eb10206a2343d82cfa7d06cd625eca2",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_applecontainer/_applecontainer_workspace.py",
+            "sha256": "1b2a2ae494400d9cec2b43b9445d5dcdf094c7dea6bd42ad4d3dee58b6ee243c",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_applecontainer/_constants.py",
+            "sha256": "beeb9c3ce67f0623835cbffc6e7ce31bafb25547170e4781308175b9c76f7472",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_base.py",
+            "sha256": "b7434df487001c5f0f1b8ab76a8e5ffd4f6841e38c5ceeeae84e08a954de7e06",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_bubblewrap/__init__.py",
+            "sha256": "6ba2fc737404df3edfe3fc832dcfa22a0609e8aafd16f30feddf6b584990ecb8",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_bubblewrap/_bubblewrap_backend.py",
+            "sha256": "4b48d691b4025c9185e0fe94039d243eb36c825c9c8dd61b4f4636492ffef8a5",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_bubblewrap/_bubblewrap_workspace.py",
+            "sha256": "69d828654bd0b34fef057e4b3d4c8565595f91e7989ea73fdcd2309c7315498e",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_bubblewrap/_constants.py",
+            "sha256": "069450b643db135c54bd49afc3e14390019965cbb5f421b5e46d057acb3dac1e",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_daytona/__init__.py",
+            "sha256": "b696ae03aee258be9891655431b5ac6be68ecd4879cbefbc453ae8a73bae8ecd",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_daytona/_constants.py",
+            "sha256": "f174ebf8314328e71d7bebafd0ce0c222b241539a9e8b7beb7f6580a4565db4b",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_daytona/_daytona_backend.py",
+            "sha256": "7e3120ccce12cd8c000308ff5d0a331957d73285c0a986c275bb27e44bcb877f",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_daytona/_daytona_workspace.py",
+            "sha256": "af4428529dbfbbc7d468113da91e4153cc3101c0b73c2968046a10b546658b51",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_docker/__init__.py",
+            "sha256": "d585bc666e347d8532e8a3f6250b2685af2b9628fee2ccbc1cb4c40304fa94ba",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_docker/_docker_backend.py",
+            "sha256": "ecbf3e33b4a0ea18799503a999873c61de314f2f235bc54c0f04bcd5ee3590c4",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_docker/_docker_workspace.py",
+            "sha256": "49194c0b43ba5dba028129d83faf8ed2f6916dbee0796f27adedeb8a8f347a26",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_docker/_make_dockerfile.py",
+            "sha256": "5b051e9da88989081e4f52c4696064eaf77273a99a3c3a0d4104c3b8e89f9275",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_docker/Dockerfile.node_copy.template",
+            "sha256": "bd1c6654e2df24a13fc4ad1c1fe3f2e94840a3e0d403aa08c9078cc0c7b07ea6",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_docker/Dockerfile.node_from.template",
+            "sha256": "2cf4fe21f72228849e53c170c985e2da6d9548c0311512427a703a677801c5bf",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_docker/Dockerfile.template",
+            "sha256": "d1179ad4bc4b905e7e273bd57a16e1643a16081cdb81d3e35065e8540541c10c",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_e2b/__init__.py",
+            "sha256": "ec3ca3704baa32e36b3b3578fd91ca0cf80415dec09cb9c17c2d3c7521ac4c99",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_e2b/_constants.py",
+            "sha256": "45a632d4fa46ce25d063acabc074881c53c8b452e8f776dc9a7ed1fe14d4c1d9",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_e2b/_e2b_backend.py",
+            "sha256": "4b24fe7c5f845365d892550d05e179e12e4a7fc76ab43f11c3030bb81d4b363e",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_e2b/_e2b_workspace.py",
+            "sha256": "e983d674f5f1d9c231de1211508717af2a64bc0056b818dc3338de77f98f76c7",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_gateway_client.py",
+            "sha256": "9c7a07b5150c6f0a326036056361d7dafedd7b65a655db7b2ce535d3e26adab1",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_gateway_shim.py",
+            "sha256": "cc02c8de7bea82dcd7da2142598ab9ce28bdd79b81b3cde1d239b64ea9ccbb67",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_k8s/__init__.py",
+            "sha256": "f3defea55338d1d4b1997d25355c17a7f93f4221565f7379a1077a7a5fb3b57a",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_k8s/_constants.py",
+            "sha256": "e49f279db0ee48bdaafc092e6ee25441a17390c31dfc91c8e54107af2481ce13",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_k8s/_k8s_backend.py",
+            "sha256": "a5e0981611cfc7d0ecf3e0418cad79643b94d6589472f68a385f9add5b85a734",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_k8s/_k8s_workspace.py",
+            "sha256": "cfe16d68ba6e45ee42f65042cb4179ea5755e4345943bde0b1065cb9f68faf62",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_local_workspace.py",
+            "sha256": "880d1afd5ae159ee155d462f15bdb79e044678d2a69da9f123e9a43f74479a8c",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_mcp_gateway/__init__.py",
+            "sha256": "bae17fffd55ec08705183ac9bf33ea794206e0f0edc917789500b2ca695b6d84",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_mcp_gateway/__main__.py",
+            "sha256": "5741be64b6f7e2fc2d8969a4ae320915734fdc5adeacd9985bc884e8cf06075a",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_mcp_gateway/_mcp_gateway_app.py",
+            "sha256": "6cd8de777c069f2559ab56df693fe78b9ba44439d59b76e80b291ac949eacb09",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_offload_protocol.py",
+            "sha256": "cb79a0a1a3bbaa56ab4538408cb8ba04faef026313eb4fd05508fee684c5042a",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_opensandbox/__init__.py",
+            "sha256": "fd24918d6404b54e7c946aca3553f22f12afa46db4d6d796829b4b0e3b4bcca2",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_opensandbox/_constants.py",
+            "sha256": "057437edc969c1573b906836e2fd5530384c57ed308d948c094c4e91e34ec5fe",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_opensandbox/_opensandbox_backend.py",
+            "sha256": "233b7806054bd92363241ac80d8144061776ad2cca63143b41ff922d81e171d0",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_opensandbox/_opensandbox_workspace.py",
+            "sha256": "14f1afa56daf534f958d1fd7964c4aa268e55ec98e2027ebfa69e06768ed0d1f",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_sandboxed_base.py",
+            "sha256": "1dc9efecbdbf3026d764fa1adee848eb1673174e453ca5a198c374c6894bbe9d",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        },
+        {
+            "path": "src/agentscope/workspace/_utils.py",
+            "sha256": "ca8841035e0765f6597d0751cbbe00b14bf9913915bd36a36365657b9190e97b",
+            "module": "workspace",
+            "typescriptTarget": "packages/agentscope/src/workspace",
+            "status": "mapped",
+            "pythonTests": [],
+            "typescriptTests": []
+        }
+    ],
+    "contractDataFiles": [
+        {
+            "path": "src/agentscope/embedding/_dashscope/_models/multimodal-embedding-v1.yaml",
+            "sha256": "63971291af9ff8909d224f036d53029d1577c3e8a38684ec70941920f9f7a44b",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/embedding/_dashscope/_models/qwen2.5-vl-embedding.yaml",
+            "sha256": "66dc582f7eadceeadb86c887d84c531ca0a4649a263c1a45c0908a4f31ccb2e5",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/embedding/_dashscope/_models/qwen3-vl-embedding.yaml",
+            "sha256": "a13392232106b0420507e764e076241759b1cc30138936cf9e421bed7cb40b21",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/embedding/_dashscope/_models/text-embedding-v3.yaml",
+            "sha256": "73fd9dfc6b1b650fc5b0d7264e063bfde4b76e961fddd58f06e204c208a23d8d",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/embedding/_dashscope/_models/text-embedding-v4.yaml",
+            "sha256": "bf3d5338e9fa0a7a573558e4b6ccf3ddc5cc04bc344e1751ba03ea20be1e5e27",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/embedding/_dashscope/_models/tongyi-embedding-vision-flash.yaml",
+            "sha256": "3644dcb26798b0eb2d3a2d39d21db084d969969a4a571f76351b8f035706fa6b",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/embedding/_dashscope/_models/tongyi-embedding-vision-plus.yaml",
+            "sha256": "123d42c0f19b2b6d8839bec9f81386edfb907fc2aff9d6a9c1edefbad169c272",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/embedding/_gemini/_models/gemini-embedding-001.yaml",
+            "sha256": "d4560b2afe088cf6e1df9ae6196b6d3b1ea904dba94744a433dc10312367651b",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/embedding/_gemini/_models/gemini-embedding-2.yaml",
+            "sha256": "139c0505244584cce5d04f1dc91c442249bb42114bcc62253593ca656f7c805f",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/embedding/_openai/_models/text-embedding-3-large.yaml",
+            "sha256": "9347231542b50cbd2a336e4d90d7e7dfb563fa72a37770f52ebf207880700181",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/embedding/_openai/_models/text-embedding-3-small.yaml",
+            "sha256": "1dc140faddfff1dde6474e2ea2d353d49eedfc01198fe006e92ccac05f8a117a",
+            "module": "embedding",
+            "typescriptTarget": "packages/agentscope/src/embedding",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_anthropic/_models/claude-fable-5.yaml",
+            "sha256": "119f0fa1bc671fc2186a696904ad45d08baf21c92fb76f225289fa9fbaa4f992",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_anthropic/_models/claude-haiku-4-5.yaml",
+            "sha256": "fb7a2befd837ddcbd5e0dabe201286cf9f528d9b609972f5395821d43480be96",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_anthropic/_models/claude-opus-4-5.yaml",
+            "sha256": "720dcfb14ae6c2991e42b4356ffcad6b9e5875d151c15bb59e0bc4b0ecd9e3c6",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_anthropic/_models/claude-opus-4-6.yaml",
+            "sha256": "d1a61d6a0b5bb8fe709bc95faf3b124a3a49b4f410fdf81ebc77f56d0bb584ca",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_anthropic/_models/claude-opus-4-7.yaml",
+            "sha256": "c27bf73983803e95148c58f59497e623e424425b0a66a9ed48766c1925ec5719",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_anthropic/_models/claude-opus-4-8.yaml",
+            "sha256": "fd17e249d4ac29486a47d7986e7c8ea8ee6ab3239e65375143d1f9496533ee3d",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_anthropic/_models/claude-opus-5.yaml",
+            "sha256": "0162332c776869415ecb7b69f147d5fffd4a576421130fd67e1d174bb30825a6",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_anthropic/_models/claude-sonnet-4-5.yaml",
+            "sha256": "e674b1d98da7779249a004de90b79bcb64e83bba4cbcd556e91e3da6b6721fe6",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_anthropic/_models/claude-sonnet-4-6.yaml",
+            "sha256": "f99243f2f5cb71dd56f3d699e5c9a9dc23e51721c2e85f4bcbdb6a651f6568c7",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_anthropic/_models/claude-sonnet-5.yaml",
+            "sha256": "91cc468d538b3afe79c91decd62a11ecc90b5630f5aba005456fd3a2b7186cd2",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_dashscope/_models/deepseek-v4-pro.yaml",
+            "sha256": "4c11da3fac6fbc68f5e3bec0c31fc6f348800f4fd2c7d855ada01a96bf0abd3a",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_dashscope/_models/glm-5.2.yaml",
+            "sha256": "927384e553169563cf5fcce55356c0a23ff7767a9d9b0be85e3630593d6d84ef",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_dashscope/_models/qwen-flash.yaml",
+            "sha256": "45f72790221ba490af9ef21c36ffb851da44524c367db17e3c97be03b2d2cd45",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_dashscope/_models/qwen-long.yaml",
+            "sha256": "fbc4afdf1cca4361f67f3a933a31425aa843bb73f17c7d3c8f1586467e01b5c3",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_dashscope/_models/qwen-plus.yaml",
+            "sha256": "696729eceb7c8f12e99527c29ef18c44bb21221bd3e07e6b1328a31301af1132",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_dashscope/_models/qwen3.5-flash.yaml",
+            "sha256": "82954b2423962805e9cafe4e80a5831c9061cf27d3eb5849ab51d815c243d3aa",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_dashscope/_models/qwen3.5-omni-plus.yaml",
+            "sha256": "1fdcd0aeacd805bef1ad88c0a73f82a98fe89e6c05b2f93d25c2dca350bdff25",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_dashscope/_models/qwen3.5-plus.yaml",
+            "sha256": "5b5d1e2f4f57d5f9a04419eb17aed33cf9b27cad953234364ece4bb7d4135ef9",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_dashscope/_models/qwen3.6-flash.yaml",
+            "sha256": "c009207b576cb2468bda1f4c88ab2558cc4f8270d39830cdfaa1def80fcffc1e",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_dashscope/_models/qwen3.6-max-preview.yaml",
+            "sha256": "0ba67a4c7ce3465bd09a9d76efee27e917669aa26de736835cb8f16e339be38b",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_dashscope/_models/qwen3.6-plus.yaml",
+            "sha256": "02b1a3ba1bba3ba34d4ddc9ede0cd7793de97dfb5a2d043f20a4aa761f1b7ac9",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_dashscope/_models/qwen3.7-flash.yaml",
+            "sha256": "c1b38dd8084d37f2a1baf953693202a96ceb4b01ff36961620ea58a111c9f0f6",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_dashscope/_models/qwen3.7-max.yaml",
+            "sha256": "14d1eca35ba772fb5676fd596bcf06e964e49556c387c5868e2ea4aa7a8462f4",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_dashscope/_models/qwen3.7-plus.yaml",
+            "sha256": "7f5fe5cb678cd823e4658bec4ff56f6baca37336f856feeded780aea9f751e01",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_dashscope/_models/qwen3.8-max.yaml",
+            "sha256": "25ce3e04dd919f4cf07f06c0f34ef0181a838bc61d4ee43f9a9e9890f0e711cf",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_deepseek/_models/deepseek-chat.yaml",
+            "sha256": "a62649b74bda0c86818d0b3c9a5ee4841e4ea9a3a37d8e16268cbff417c2d3c5",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_deepseek/_models/deepseek-reasoner.yaml",
+            "sha256": "d9ff0083b8d430a279875bd7dd74d4c3e12eadbb56f96545cbd93d124f6810f1",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_deepseek/_models/deepseek-v4-flash.yaml",
+            "sha256": "a70a1416ea51921ee73b5f99573ede43be5acfd9ad1e147af2c8c8cebc290b4c",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_deepseek/_models/deepseek-v4-pro.yaml",
+            "sha256": "7aa9b770168e89bce78e040655f514f5c6f47839c7be881a5ac9c4674435bc4f",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_gemini/_models/gemini-2.5-flash-lite.yaml",
+            "sha256": "c830357ac7ed66aac70006c2a85da9b34af75a645474bf3cb26173ecd8095143",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_gemini/_models/gemini-2.5-flash.yaml",
+            "sha256": "212631000c94c4954051b69d64f1ad32c011189e9c9176ddd4234752978f2286",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_gemini/_models/gemini-2.5-pro.yaml",
+            "sha256": "2b297040983c5fc01257e7fe7f6168546b1d11533e66f12a61877c087c26ab63",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_gemini/_models/gemini-3-flash-preview.yaml",
+            "sha256": "ddfc6d64d55c630d0aa1012a3eb9d26d4c2df10b96db5291b90a099842522ab5",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_gemini/_models/gemini-3.1-flash-lite.yaml",
+            "sha256": "ad9705d375af7dec920aad0b7b179fa374f2517ae5ef792fa909dfa35fc42dd8",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_gemini/_models/gemini-3.1-pro-preview.yaml",
+            "sha256": "147afb8555f385fd5623c08b2db8caae0fc48383ca9ea7607de688829925f55e",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_gemini/_models/gemini-3.5-flash-lite.yaml",
+            "sha256": "11087ea40a2e2f49824962cca26b8d14f6ac48fa87a79b8a301b419bf1081b19",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_gemini/_models/gemini-3.5-flash.yaml",
+            "sha256": "c9558a97ee32bfb2d5ed19730837bf12e46a515b7fbab2fd74fcdb632c18fea0",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_gemini/_models/gemini-3.6-flash.yaml",
+            "sha256": "4a246962bd4292b17761874b25828c5a79e5741db30c690bda2989ae41dc8a22",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_moonshot/_models/kimi-k2.5.yaml",
+            "sha256": "692cd70678928ccffea4230d568cf1a3eacb58c54497a453ef4fcabf16520acb",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_moonshot/_models/kimi-k2.6.yaml",
+            "sha256": "aa6841688ef782d41d8e9d28f2714735b4f89e042028a7534d4d6d46f4736906",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_moonshot/_models/kimi-k2.7-code-highspeed.yaml",
+            "sha256": "3af4dec0f922e4398f386a98160b52006009b62584fcfc335f8beb6eee821633",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_moonshot/_models/kimi-k2.7-code.yaml",
+            "sha256": "29ff41686a4c871e9b2e70217cac97db14312b414cd3062ebe599a670f5e448f",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_moonshot/_models/kimi-k3.yaml",
+            "sha256": "e9c6938898f05961320c9a1ee919035c09a18fd8364e366d7f6189613d4e826f",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_moonshot/_models/moonshot-v1-128k.yaml",
+            "sha256": "b4ec4ee8125b4fad0f9a3472bd39a5e4f9de20074b61ce91c693c35c2812a58c",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_moonshot/_models/moonshot-v1-32k.yaml",
+            "sha256": "f72fbe276149194746525556a578d95129b4cb0976abd1bbb0548c38afebff34",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_moonshot/_models/moonshot-v1-8k.yaml",
+            "sha256": "f3e4e30208bd29ffd0498674adf7946537f0454c86c4a9a780b5e4b7dec8c9ea",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_ollama/_models/deepseek-r1-14b.yaml",
+            "sha256": "33dba343b3221aa47a7e8e98180898c97f92c0d355699b83a1623dc4649cfd1e",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_ollama/_models/llama4.yaml",
+            "sha256": "d0f6c4efab8a27c74a9bbf1a4923b434934221faec727881b49242378648eb44",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_ollama/_models/qwen3-14b.yaml",
+            "sha256": "73bc14af098ad643336b3b1bffa1b73458b35741e8bd8658403bb5490ef0df86",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_ollama/_models/qwen3.5-9b.yaml",
+            "sha256": "30c62a15f7304c469f2930e47a0a5f7fdb0699565410d4c9f4009335d4655324",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_openai_chat/_models/gpt-4.1-mini.yaml",
+            "sha256": "66875db1ae63e257fb378f47d5d539aebeab8e2e16c6ec48a2f4da18f167e1c1",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_openai_chat/_models/gpt-4.1-nano.yaml",
+            "sha256": "77e345f9c22e006c09a90f1d3a5075d48dfa2c1915b43aa36099be7944cfbafc",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_openai_chat/_models/gpt-4.1.yaml",
+            "sha256": "0435a69e084c47bbc2856f5e2dcd9fe90478cff081b0ef8b45a76d06673c722c",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_openai_chat/_models/gpt-4o-mini.yaml",
+            "sha256": "863dbe1f3d6446615390c9ea2564d41a352118b3bb29a6880b8704f83797e5d2",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_openai_chat/_models/gpt-4o.yaml",
+            "sha256": "635bb35b0b524a71665ae9901f510209b1fd849826b398ec96322a0c78e73197",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_openai_chat/_models/gpt-5.4.yaml",
+            "sha256": "c618fb00a4e1e0d17ae9934a0cea1c92a6e80e9318e8a436bebc5600247dc1c5",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_openai_chat/_models/gpt-5.5.yaml",
+            "sha256": "0643a8dc26f4845f5c13bc78501e6367fdf9c78c9cc6f6177143f394fee0bb29",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_openai_chat/_models/gpt-5.6-luna.yaml",
+            "sha256": "e8ff4d04be217ac7b6fd5181a8f23f7936b03b83d3fd6054c34c6f1a6a2643d8",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_openai_chat/_models/gpt-5.6-sol.yaml",
+            "sha256": "5dea8643d23e33e93b4e0ec05946c35deb94b1456f015c7bc558e60288b37265",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_openai_chat/_models/gpt-5.6-terra.yaml",
+            "sha256": "ed69333a7e57ec90bd6828297cbfc38cd5410ca61079b5328671be7b500b853b",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_openai_chat/_models/gpt-audio-mini.yaml",
+            "sha256": "a3e7671c83fad589cf936fc377314423ce340593fcc47c8b3736759d1297ec2d",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_openai_chat/_models/o3.yaml",
+            "sha256": "85c54a3e888bf966d1b5563db5d1e4b33427538a32913470c1b07fc3c68eb230",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_openai_chat/_models/o4-mini.yaml",
+            "sha256": "65cee051abd7e978d36b5c7f471c0b8f84f0abe694797d24ead12525a26a975c",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_openai_response/_models/gpt-4.1-mini.yaml",
+            "sha256": "97756003301ed9bc450107356d69d31a3dc1c9382cb8d7eb6b897692f1caa2b8",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_openai_response/_models/gpt-4.1-nano.yaml",
+            "sha256": "8cec838785ba60619eddf365873216f48a582e22dc4c75a9974fd4827f23764f",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_openai_response/_models/gpt-4.1.yaml",
+            "sha256": "2ba011f92521198e0c8e796d5cdbe9d35e98b305cd0d5235f847621f0a6f25bf",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_openai_response/_models/gpt-4o-mini.yaml",
+            "sha256": "d77ffe688b967a6f0d783c5b43c369ed16d16496ac5a67edb5918ded29852faf",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_openai_response/_models/gpt-4o.yaml",
+            "sha256": "51cf4dfbb946d0d91caf8d180114013ba322dcf5d8d6f8bcf41da97fc49f27a2",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_openai_response/_models/gpt-5.4.yaml",
+            "sha256": "3060e27b46f1060eef7788d21179f3f4b074620ff25adbc8b7f3749bb29f4ee3",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_openai_response/_models/gpt-5.5.yaml",
+            "sha256": "5caf5f06645b8b7ca1c227697d20978e9fe76eae475f132f9d6aae1ccab64625",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_openai_response/_models/gpt-5.6-luna.yaml",
+            "sha256": "24d06ec18abae806b5ae422864649b1f0f500d8689d2b63577943e8b1d3f53a3",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_openai_response/_models/gpt-5.6-sol.yaml",
+            "sha256": "2b0d867510e860e783bca8e38bf2d14e171a2b7f6b68fdd0841ef51245349aa6",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_openai_response/_models/gpt-5.6-terra.yaml",
+            "sha256": "b2d3d8edaeb2e7c445b65915a241de49e09d9e732038c9fd556f68a32b1e941f",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_openai_response/_models/o3.yaml",
+            "sha256": "dcac98914ed6473dbea116c1bca1171142fa2babe927a9c8986ba7188dcefd62",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_openai_response/_models/o4-mini.yaml",
+            "sha256": "8cd9866be3ac797f5fce47ec77f8a0b74311e061acbb7429e77d2038d4a876c9",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_xai/_models/grok-3-fast.yaml",
+            "sha256": "395d55938810c53266e05aec3445925a133e324ad3da3dc043b43ad28f42bdd4",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_xai/_models/grok-3-mini.yaml",
+            "sha256": "5bfee49f228d9a87295b39b640543d06fc2345cb69a734ae69e5989e4ad9b9ad",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_xai/_models/grok-3.yaml",
+            "sha256": "c0b5b9013d61088908e79eef35ef9fa3cdbb8f4837b3d6d6af008fa12be42435",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_xai/_models/grok-4.20-0309-non-reasoning.yaml",
+            "sha256": "6208ff44658b929c59f3be3b6dc2151d1d2eda59cf1c10a1db316cc8d9dacd60",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_xai/_models/grok-4.20-0309-reasoning.yaml",
+            "sha256": "3ad052ba7573c8613d73ba8eff11892e91b28ce789980eb597f9d40ff27d32f6",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_xai/_models/grok-4.20-multi-agent-0309.yaml",
+            "sha256": "311a39f3b957546e4dfdbed3eb48b5acc529c9415d0fbee006d400a3655d2a26",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_xai/_models/grok-4.3.yaml",
+            "sha256": "51fea8b5be3bf48e1b72d0e163dbb22359c384e50ed3c5ae4e86c552806129df",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_xai/_models/grok-4.5.yaml",
+            "sha256": "d5fa142095c21528cce9fb3d4fc11b4517a87dc11ba76df04098f7b8eea106f5",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/model/_xai/_models/grok-build-0.1.yaml",
+            "sha256": "b452cd19cfad8baf436bbc8f604bad99cf16e910c4f39246d4e2518d9fcdae0d",
+            "module": "model",
+            "typescriptTarget": "packages/agentscope/src/model",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/tts/_dashscope/_cosyvoice_models/cosyvoice-v3-flash.yaml",
+            "sha256": "6a54a5c1c712dff31d63d274e843002f28ac5de3b518a6c5ec7ad1ebc2e682c9",
+            "module": "tts",
+            "typescriptTarget": "packages/agentscope/src/tts",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/tts/_dashscope/_cosyvoice_models/cosyvoice-v3-plus.yaml",
+            "sha256": "5aaad05888c42807f80bb95bab17b044a80d4837b71ff65dc6401b3630e486fa",
+            "module": "tts",
+            "typescriptTarget": "packages/agentscope/src/tts",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/tts/_dashscope/_models/qwen3-tts-flash-realtime.yaml",
+            "sha256": "0925bb9676998138b489eebfc4ae8009133e7ba5047a3093c1785ce3b3581f2c",
+            "module": "tts",
+            "typescriptTarget": "packages/agentscope/src/tts",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/tts/_dashscope/_models/qwen3-tts-flash.yaml",
+            "sha256": "1a19821bde26e73a9d91faea7754acc1cb0d893d8688ef6a0feaa064954c3f78",
+            "module": "tts",
+            "typescriptTarget": "packages/agentscope/src/tts",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/tts/_gemini/_models/gemini-2.5-flash-preview-tts.yaml",
+            "sha256": "b5ab14260aea44ded30b5f67b632fc512e05134c6b0922d1799a81932c0c2cc9",
+            "module": "tts",
+            "typescriptTarget": "packages/agentscope/src/tts",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/tts/_gemini/_models/gemini-2.5-pro-preview-tts.yaml",
+            "sha256": "2e3a7656b3cff58463e6b82494d24514e68931f718759fdf8550a92636f342c9",
+            "module": "tts",
+            "typescriptTarget": "packages/agentscope/src/tts",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/tts/_openai/_models/gpt-4o-mini-tts.yaml",
+            "sha256": "71d19e8b22318d5c21ffdfc06c70d00ebadb4dcd5fa43fcdbfcc8cfd17cf2cfd",
+            "module": "tts",
+            "typescriptTarget": "packages/agentscope/src/tts",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/tts/_openai/_models/tts-1-hd.yaml",
+            "sha256": "8e2c0cdb1c60b3da2be5e81e4cb3daabb4d0095449ab2644999845623121dbf0",
+            "module": "tts",
+            "typescriptTarget": "packages/agentscope/src/tts",
+            "status": "mapped"
+        },
+        {
+            "path": "src/agentscope/tts/_openai/_models/tts-1.yaml",
+            "sha256": "b18cbba0f5e0ca314fdb223d911cf91016b9459839fe97678741668527007baf",
+            "module": "tts",
+            "typescriptTarget": "packages/agentscope/src/tts",
+            "status": "mapped"
+        }
+    ],
+    "testFiles": [
+        {
+            "path": "tests/_daytona_live_utils.py",
+            "sha256": "645734e677ac53a941432f7eb961af2b42f4924d9290ad7d294fa69dd1c7459c",
+            "area": "root",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/agent_basic_test.py",
+            "sha256": "fa0d38560b10c6282e618ec9fc89834c91f368996ee7d10c815404347033aa78",
+            "area": "agent",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/agent_injection_test.py",
+            "sha256": "c9fa4fd48093820daa7ece558be1878cd59bfdaf45753259a28f1845358cae05",
+            "area": "agent",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/agent_interrupt_test.py",
+            "sha256": "3bd7c58bf86796b18641914e2a8e044154db371824b15f60865558c5a2f16b3a",
+            "area": "agent",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/agent_structured_output_test.py",
+            "sha256": "f7c398f425144fb15adc1714c41aaf2ebd1784bfad7b9815c423611c3f4ea1e2",
+            "area": "agent",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/agui_protocol_test.py",
+            "sha256": "3881992fb0fe5a61e779c9c0e7b42d07e143f9dfcf87adecb6f35da73b744458",
+            "area": "agui",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/app_lifespan_dedicated_test.py",
+            "sha256": "f8ce21988e087c2ec92f5a0cb62796b52b95d8248f374b916cff82cfdbf8da8d",
+            "area": "app",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/backend_applecontainer_test.py",
+            "sha256": "498274a2139dce50e4e3a5b29715f35be45fc0a096443eb42db11454ac1af614",
+            "area": "backend",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/backend_bubblewrap_test.py",
+            "sha256": "c1b3b46eb5b4356339e5ea4793ac8a26a76766fa5342a7f664f40b3fbda45a15",
+            "area": "backend",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/backend_daytona_test.py",
+            "sha256": "aeba9949044cd3e3ae287b9599bb8049c6a6d16c2b13225b92c719bd660ff327",
+            "area": "backend",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/backend_docker_test.py",
+            "sha256": "7a4047af8fb8552af851984584f98abb6f8f426a752ec41c1a49aede920b5452",
+            "area": "backend",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/backend_e2b_test.py",
+            "sha256": "2fcf51756ec048466edbdb6414c692673aab6af6f94066736aa23b32a1c281b5",
+            "area": "backend",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/backend_local_test.py",
+            "sha256": "af61c6ae43bce44afbc5dc5bb4976fe94ef77480914db01d687db8e6598cbd9c",
+            "area": "backend",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/backend_opensandbox_test.py",
+            "sha256": "c7eece7997efd5183730f7661180a257cfc5699187a352f217c7d9678fbb957d",
+            "area": "backend",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/blob_store_s3_test.py",
+            "sha256": "76e89254b383c4ca85f3e71aae3ff074cfd93a66508b79e7131ff6ef59173b67",
+            "area": "blob",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/builtin_bash_test.py",
+            "sha256": "052f4453d624b78b0fdb7d6f0428c37762ba38e4e9bcc41b1d0308c111e82dc7",
+            "area": "builtin",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/builtin_edit_test.py",
+            "sha256": "84c7f8c957d211ba09fa462acc9036cce03520a37c3c2a7b15db0f773ef54c00",
+            "area": "builtin",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/builtin_file_cache_backend_test.py",
+            "sha256": "bf7e27f8576d1716b38e9f63ccf59aae2692834431b051097ceb6575784b7910",
+            "area": "builtin",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/builtin_file_cache_test.py",
+            "sha256": "96f7c7f73d48c6b49e39dc95c606af7cfe8766ea9ff4a1aa605244faec3d0486",
+            "area": "builtin",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/builtin_glob_test.py",
+            "sha256": "c812a16b593aa4a3534dbb3fec94a336f1a7bf4a3585ebea16f5a700debb7d6d",
+            "area": "builtin",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/builtin_grep_test.py",
+            "sha256": "1e3c086a004f5c59e7673ae9796955b5548e14419648f9123cd72cac0633bf9e",
+            "area": "builtin",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/builtin_powershell_test.py",
+            "sha256": "e0226b92fbc4e4d59d4c6e4dd8a53fe483be30f1b1b80be3311454fa9e638c8a",
+            "area": "builtin",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/builtin_read_test.py",
+            "sha256": "733622e22cf4d1762d4f0eccddf031774158f3c773ee7c80f2d1fbd7a78b0e74",
+            "area": "builtin",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/builtin_write_test.py",
+            "sha256": "e6a4cff25dcfa51a17e312647ccd80b5ce81daef3afb73fe6d039282f267d9d6",
+            "area": "builtin",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/channel_clients_test.py",
+            "sha256": "34ccf8b18f7d720790ccc23ba7f94d41d30975499b2f3f095b176920807b0d23",
+            "area": "channel",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/channel_dingtalk_test.py",
+            "sha256": "2dc4313b0bb45bf09683578996bbd95b9a080c90df9a4f27f66c2031990b5fc7",
+            "area": "channel",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/channel_gateway_test.py",
+            "sha256": "b56aeffb647651580ef68a4b27e8bea938fe97562b254a038e84a8dc93c99e09",
+            "area": "channel",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/channel_routing_test.py",
+            "sha256": "797adc942a28685859654a4686e98415752498ff6877a08c3d9d012f85b7ed26",
+            "area": "channel",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/channel_stream_test.py",
+            "sha256": "b982049bc9991e75d29d85889d448a57eb1360b8ee080c195ad3174dac0fa9fa",
+            "area": "channel",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/channel_worker_test.py",
+            "sha256": "85a8f056f90355092b62a02563b9c335c1e3fd8fd1bf6916420c8818b42d9a4f",
+            "area": "channel",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/compress_context_test.py",
+            "sha256": "f7b1d193580c6a7f5dbcfc197e7075f21e97a007e18178e6b6d44f53d8cd556b",
+            "area": "compress",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/compress_tool_result_test.py",
+            "sha256": "075c8105d371cc5abc016e34f88d13252ecc3817df5cbd779aa0ea9d33b17ba7",
+            "area": "compress",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/console_renderer_test.py",
+            "sha256": "eb99ca587d8033c33446fc34de7a7170140b1575fe7e923291cc980c4c868cf9",
+            "area": "console",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/docker/k8s_workspace_test.Dockerfile",
+            "sha256": "80beae780623b1341d875f95db3f1f39527e4fc28078256fac4b6408d885c939",
+            "area": "k8s",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/embedding_dashscope_test.py",
+            "sha256": "bd0a72dff5ef6aad320f51198fa099a2390118c9915fb672ef42c5aeb5f63db1",
+            "area": "embedding",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/embedding_gemini_test.py",
+            "sha256": "63afb5b6c7b3c4610029ca22bbbe039597db61485c1734c0bd8222b006c8e4d4",
+            "area": "embedding",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/embedding_ollama_test.py",
+            "sha256": "8d9a5fcf68d9a01d28471a6c9adad479312cd38bdc6aaa59ed058fe0312fae48",
+            "area": "embedding",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/embedding_openai_test.py",
+            "sha256": "d40c6b2633c29bd028ff118ea808d685d05f329de08778724aebc03fd8cfcdca",
+            "area": "embedding",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/event_test.py",
+            "sha256": "9c94db2ad532d1662a5f29f046e25766f073ef3b83cac56b58d02d3c1fc1625c",
+            "area": "event",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/event_to_message_test.py",
+            "sha256": "22d8a5b93df7355549fe8f0d5628e1275c510e986c753f81bd0186ab4ebea036",
+            "area": "event",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/formatter_anthropic_test.py",
+            "sha256": "00136176a9ac5f32fbf68e787ba67181e2050ed681f15c9721984b54fbf58a89",
+            "area": "formatter",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/formatter_dashscope_test.py",
+            "sha256": "64fbcc749774f15ef0439dada0047e663a7a03ad7f0af374bd45118bef626331",
+            "area": "formatter",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/formatter_deepseek_test.py",
+            "sha256": "70d68c2f78a70d718c45ac89f68db0d87e9e75d77da7d3926509ee24221c6229",
+            "area": "formatter",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/formatter_gemini_test.py",
+            "sha256": "1eb68465f79eb8c97a62eafecbfd069cb32a15c4f9173978e0ba783943570904",
+            "area": "formatter",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/formatter_moonshot_test.py",
+            "sha256": "b799fd9fa51b316d86ebdc110b33098872b6907a300c1dbe83f20772e64d9dbb",
+            "area": "formatter",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/formatter_ollama_test.py",
+            "sha256": "1c1fc920596cba6280196c28c55ba8edfaba2b79aed50513fb25c77aab401338",
+            "area": "formatter",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/formatter_openai_chat_test.py",
+            "sha256": "1fb39169d378c6c70ea05bba6d56b55fe1f58fac415540c717078573eac2e9f6",
+            "area": "formatter",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/formatter_openai_response_test.py",
+            "sha256": "ce06ab5aeb535b633c3cf515233b06f1be3adbc70db95d85e054c7321ddcf60c",
+            "area": "formatter",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/formatter_openai_response_tool_result_test.py",
+            "sha256": "d62ccf90f7d77439a6202424ea69c2e0343acf4e255e9886abbce7efe26e0f2a",
+            "area": "formatter",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/formatter_xai_test.py",
+            "sha256": "dead2c34c7b51d4135ba45e08e57e271bcbe913f49ac2410619e07c3b2e02d81",
+            "area": "formatter",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/health_router_test.py",
+            "sha256": "acbbc26a5e9dc096e362007820484fd94c74466e152b6051a30af5083b1c3ff4",
+            "area": "health",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/hitl_external_execution_test.py",
+            "sha256": "519b699a5d4c0a9cc5b30beebf2eddcb8f4396fc48b23d64ff70ce0cc72f8ddc",
+            "area": "hitl",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/hitl_mixed_test.py",
+            "sha256": "6b74fae73463b65cc6c913783ebc8eb88379e259c624a7af70dd1b5994e139d8",
+            "area": "hitl",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/hitl_user_confirmation_test.py",
+            "sha256": "6e5af7373066d011a43a1af59a06cb13119af5eee2eba7a7da48cd8630492555",
+            "area": "hitl",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/hub_card_test.py",
+            "sha256": "389257763c1767b697db6d005b1822ae72c7e8f7f27dac03a7828834c94ae6b3",
+            "area": "hub",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/hub_claw_test.py",
+            "sha256": "0a18882f7271f5d079d43e9174c9fa853de399d1dbaf3e279dd021283bb356eb",
+            "area": "hub",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/hub_github_test.py",
+            "sha256": "0949824f8237dc0ba9c528e72e4820016422e7a393e5be9cee60abe717190da5",
+            "area": "hub",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/hub_router_test.py",
+            "sha256": "628e8b91be238bcd3b4afea368cd10513d31b327016d20302d8e8cbfe66399f1",
+            "area": "hub",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/id_factory_test.py",
+            "sha256": "2c1eb9d3291fd2624e43ea55e40853ebb9743d1874f5a595d220dafe1f963600",
+            "area": "id",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/in_memory_message_bus_test.py",
+            "sha256": "16a2e872b27b6b3d12feccc97ff83bbd59e51f8a13b448673159db313ee4e13f",
+            "area": "in",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/index_worker_lease_test.py",
+            "sha256": "2528098027882bc8be635060e2aa8df9fdb53d88b267b03a195a9923b666587b",
+            "area": "index",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/mcp_client_reconnect_test.py",
+            "sha256": "c81ce0080dd6d79584e2f45078d0512c1672b19ef5634299595a0859174e027a",
+            "area": "mcp",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/mcp_sse_client_test.py",
+            "sha256": "c53e217a324f5465479d26713953f894be9037419f5fb9d9aacb4e2220404f93",
+            "area": "mcp",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/mcp_streamable_http_client_test.py",
+            "sha256": "25c1b3c21ec24b25e0a09c275f7656391348afc5df95453cc6ea27f642867cd9",
+            "area": "mcp",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/mem0_agentscope_adapter_test.py",
+            "sha256": "80879cf93ff83fe02c273281136753d25344d8ca314316640f3f0ca97e6ca0cb",
+            "area": "mem0",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/mem0_middleware_test.py",
+            "sha256": "ce690cf5259b79fc7cc84ebb1ccb65792e8ccbaaf09b3e98da2450774b97f493",
+            "area": "mem0",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/message_test.py",
+            "sha256": "cfc3d5b26d906230cd9f03737c4c4ffe5986045ab405921da75e48a56bb4faae",
+            "area": "message",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/middleware_background_acting_test.py",
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "area": "middleware",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/middleware_budget_test.py",
+            "sha256": "0739ae701c60711c04c7ef3669fd20a3bf6334b78c9b8fa45e8c343704d87874",
+            "area": "middleware",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/middleware_filesystem_memory_test.py",
+            "sha256": "d950d7da4061a217cfef6957e92af9e9e771bd98aa34ec23aa59f7d26221f80c",
+            "area": "middleware",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/middleware_rag_test.py",
+            "sha256": "38e6462f62ae08e41a494505c121ae6bb09e0fa696a13cf0f5e50a4b1093728c",
+            "area": "middleware",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/middleware_test.py",
+            "sha256": "2c6c0044a4815dab47d5be06e9c5b95c4702a87698aa9363180d124c37748a7f",
+            "area": "middleware",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/mixin_test.py",
+            "sha256": "dafb669565a50694fc1d9ef5b0bf2a1c07d88bbd037fe34bc272b56ee7aae136",
+            "area": "mixin",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/model_anthropic_test.py",
+            "sha256": "1096cfb948f22b72bbdc24de1b07b3e2ce61a2ba0f4239d3e3730cb30279407c",
+            "area": "model",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/model_base_test.py",
+            "sha256": "3c541e457ff2de5442f8b2506fc9058e4caeaa2bd839e9ad5cbeb693a82a38b4",
+            "area": "model",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/model_count_tokens_test.py",
+            "sha256": "049e1dcf17f5a1773e66ec3f635b759d8c36f97ee575a5dae7b2b1e3839c51eb",
+            "area": "model",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/model_dashscope_test.py",
+            "sha256": "29a870767529a6ae4f82e4a0d5d94ba28b2c382ecd463ebdecc51dff904c7f20",
+            "area": "model",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/model_deepseek_test.py",
+            "sha256": "47b8dd6178af312be4a21da099dd6ccee19db440880fd3ecda6f11b74a088b7d",
+            "area": "model",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/model_gemini_test.py",
+            "sha256": "8a7cdb3dbbfdfcf8a5f43bd5536ce588ab33003a8a0d2005813405371833150c",
+            "area": "model",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/model_moonshot_test.py",
+            "sha256": "f23fff8bebbf7a9c1165fc6382cdcba30bed17dc4d9b26820f9e180a7d473161",
+            "area": "model",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/model_ollama_test.py",
+            "sha256": "38e80a7aebc498982ae6de0748d5dced270074f0f929f400b9625f0d6d3ccca2",
+            "area": "model",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/model_openai_chat_test.py",
+            "sha256": "c6e087434a10572423897f3146419705baa238feb8aabc058f5e317d7f098ede",
+            "area": "model",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/model_openai_response_test.py",
+            "sha256": "d8430a3e41e23f5cceee42ac40801872882a44ea7111c69bfbd09b54cc633abb",
+            "area": "model",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/model_response_test.py",
+            "sha256": "9ee96bcb6904c7b57f2e0f00d7557387114c82bf08548dcd9abf6dc93c8f4e74",
+            "area": "model",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/model_xai_test.py",
+            "sha256": "8324da576ac8340bcc7e05cbebf766f78d403382b2a3a2f834d9e360963bad57",
+            "area": "model",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/permission_bash_parser_test.py",
+            "sha256": "70758361e5573f782a9cf50d046456a3857b45953760e31e5b61043f65a29525",
+            "area": "permission",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/permission_engine_test.py",
+            "sha256": "542e53cb267efc1f45f0602a5e852ac0d418b66be998aeb3d0ec2868599e4756",
+            "area": "permission",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/permission_mode_test.py",
+            "sha256": "5a79c42b23a036761befa7b5b76b0947484f0c8ce7a3364ba9bebdff44b390bc",
+            "area": "permission",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/pipeline_goal_test.py",
+            "sha256": "966f6179207bd7657abbf0db356b58e917a09b980846acfda97fba590c96715f",
+            "area": "pipeline",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/rag_chunker_approx_token_test.py",
+            "sha256": "62323c34cbeb83eb0a0198f129b7d73309c67800dafc127ed1d3ff19e7f149e3",
+            "area": "rag",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/rag_parser_test.py",
+            "sha256": "4685adca32f1535041eaeee73c70b3ddcfa72754de94701182168a05b04bd33c",
+            "area": "rag",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/rag_vdb_elasticsearch_test.py",
+            "sha256": "59c71ceb359ea164f4e9e9f03c11d614a79ab3ba4c2a36b0225e882080831440",
+            "area": "rag",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/rag_vdb_milvus_lite_test.py",
+            "sha256": "4031f2262a2e5b116a6deabd0a5324d3ea57b0cc2ed8422f23c56c3e1a6755fc",
+            "area": "rag",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/rag_vdb_mongodb_test.py",
+            "sha256": "6d4992c493a33dbb32d55495e99216e431ba95f20a030783035abecff85ca83c",
+            "area": "rag",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/rag_vdb_qdrant_test.py",
+            "sha256": "7543b7a25400d7cc73b50a550bda1767d510893ab40e7b60ae2307e12d9e226f",
+            "area": "rag",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/reme_middleware_test.py",
+            "sha256": "48425ad4c3832e7fa62ce2e1ae2d4dfcdbd350b2a05a72dd33ae64b95b13788b",
+            "area": "reme",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/resource_access_policy_test.py",
+            "sha256": "1aef6ebeed456755a9bf74300043f679a972148aa51f1e59ab91a1ba93e88bf3",
+            "area": "resource",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/schedule_router_test.py",
+            "sha256": "5e8805c2938d89587b23ea58ef099107c8007116de3b95188c6b8d70df9e7f60",
+            "area": "schedule",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/service_agent_interrupt_test.py",
+            "sha256": "5d78fb6b21b27ea94c361fdc9d2c8de29a479b347860290b76fd8cfc062beb7e",
+            "area": "service",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/service_cancel_dispatcher_test.py",
+            "sha256": "a99d0bf9f1287d77859694d8f88abc4c2d8060fc46efedc479e7b32594f41e00",
+            "area": "service",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/service_chat_channel_delivery_test.py",
+            "sha256": "119e096d3217751859bd3f9039b9b9003fe4ba72380b9a12662f4bff0c719461",
+            "area": "service",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/service_chat_locking_test.py",
+            "sha256": "833898a3230ae9e17986002783c9db1affc094f3a00ac805b54cc84f722ccc74",
+            "area": "service",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/service_chat_middleware_factory_test.py",
+            "sha256": "ecaa425739d85bc708fa0e0f32e9f7b0502f316907c51dbaabc5a39a4dcb902e",
+            "area": "service",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/service_chat_run_context_test.py",
+            "sha256": "88e193b823c4fdd27ca8bb15f3f52592ec3f4255d5f4b8b152d5b2b8a0e6c7b5",
+            "area": "service",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/service_classify_error_test.py",
+            "sha256": "51387377a87b3b6c3944021ff96ae7b454fdaa4858b2c4136ed22f61e7812f8d",
+            "area": "service",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/service_enqueue_index_task_test.py",
+            "sha256": "382186b215158714915561a5d63bde577fc42e30a5fa1cd50a2670a268eee071",
+            "area": "service",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/service_git_status_parse_test.py",
+            "sha256": "b7ec50cd845d49f9078b0c06ffc49d3a855bfc89051541cc81735fd0ecd90438",
+            "area": "service",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/service_inbox_handoff_test.py",
+            "sha256": "75a19076e6f9730f2e703e114a6cf32b550f265fe30427f70ae74785675b07e3",
+            "area": "service",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/service_inbox_middleware_test.py",
+            "sha256": "b49e42ac8dc27968b4049d8bbebefd9928aaba08b3ca2de85de91ae104c1bae8",
+            "area": "service",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/service_index_task_consumer_test.py",
+            "sha256": "6ad0e7e619e5741c4316a5c5c7ec11d2afc054797473117efda8ba8e951614a2",
+            "area": "service",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/service_knowledge_base_detail_test.py",
+            "sha256": "03fab4822bd5e4f2955fec3c3d8be31744bd10822262c552491bd957bba0ddd2",
+            "area": "service",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/service_knowledge_base_upload_test.py",
+            "sha256": "a9d1d3fd20cb0dbe24be4440c089b7074b97021d2a0873642796af0ded44159c",
+            "area": "service",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/service_mcp_render_test.py",
+            "sha256": "f9c7528a827e639462e0c560b1a3753dbd9f218a541b0f89834cd5e1c467382a",
+            "area": "service",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/service_message_bus_test.py",
+            "sha256": "d6397499c1a64e49e65051136ec85382d6ab7aea817866c6bf07a1e73d8c919d",
+            "area": "service",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/service_scheduler_test.py",
+            "sha256": "3bad12ebbea64fa78d167b26d6c7bb5e6b64954c8e09251b792fe5c71ee72417",
+            "area": "service",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/service_subagent_hitl_projector_test.py",
+            "sha256": "1d764f76d43b458d8be51332f35073b45214f4c645539db51ebb1682075a66ff",
+            "area": "service",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/service_team_failure_report_test.py",
+            "sha256": "0b0aa858b7b9b35c5a829d0bc5cf8f91c4236a4dc88ca96f1f0105fd623db280",
+            "area": "service",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/service_team_tools_test.py",
+            "sha256": "659d4a4f183e9d6fbe06bdf07b123aa340c2dc5562ad4445e76fdcdd95ae76c4",
+            "area": "service",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/service_toolkit_test.py",
+            "sha256": "9d1452a5905db845d43a9204ec870eb7b9c5df049310adbdc0d3a19433c807f1",
+            "area": "service",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/service_wakeup_dispatcher_test.py",
+            "sha256": "7624d7b3d0c939cd72a86f2e2ccbc7fd8781fa709c611c37bfff02d31dde6ded",
+            "area": "service",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/service_workspace_files_test.py",
+            "sha256": "95d574952e8dd4e95c0e1b8c099eec7630b8bc34e54f1226ae8464a346989e07",
+            "area": "service",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/service_workspace_status_test.py",
+            "sha256": "fed4c66561e8030d31c927ebf5b1f2c077c596c780cd6622cf808bf0b3cb94f2",
+            "area": "service",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/session_config_patch_test.py",
+            "sha256": "fcf3e94d88fbecbabee96e4e80cc3f229636c8f61cf7f85d51a2eebcf339b531",
+            "area": "session",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/skill_loader_test.py",
+            "sha256": "9083f09afc8a13f4056ffd39693aafb9b71472be198ec24aad13cef0a9518782",
+            "area": "skill",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/storage_redis_knowledge_base_test.py",
+            "sha256": "c2ebc1653b74884d54192d53db658712c3af1b0a4e0d23c0fff58c3b28b47576",
+            "area": "storage",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/storage_redis_test.py",
+            "sha256": "b1e9b1eddc6684a1270ddd1073cf8ea35ff1fce33b21b88a19a2ca87ecfe61ce",
+            "area": "storage",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/storage_sql_test.py",
+            "sha256": "b1330382d2121d9e916b7869ea1a5d7f82b00e6006f76ff90c72fd0b8a554c7f",
+            "area": "storage",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/task_tool_test.py",
+            "sha256": "5c63b8c4e4699151bd9a6bcbfe4350279e5df0d9a16464d2a44f674ac603338d",
+            "area": "task",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/team_member_middleware_test.py",
+            "sha256": "130be9c12a4950824111fdd28774719f4cee7e4ae35d5f726139ede6b03b16f5",
+            "area": "team",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/test_e2e_api.py",
+            "sha256": "4214d4b22e82af34c9efc32abef22a5cdde08bf1df3de09db15df303e27de4b6",
+            "area": "e2e",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/test_e2e_docker_mcp.py",
+            "sha256": "65476273f6af8470d7fd42339c114c3ae6c8f204169a74224f307cc6b7c151c1",
+            "area": "e2e",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/test_e2e_e2b_mcp.py",
+            "sha256": "e06ad9cdc35b49dc425df5f9733cbb1ed1ec5609f436af8427a62d195fa78d2b",
+            "area": "e2e",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/test_template.py",
+            "sha256": "03ca308abda0718da566729cdff1cf6a04e7afaf4957dfc3ab3e438b952e3353",
+            "area": "template",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/tool_lazy_annotations_test.py",
+            "sha256": "1728a9c0df1f046413f2751e4dfc583ab3d94d7a1e999d9137cc80b47995f75d",
+            "area": "tool",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/tool_middleware_test.py",
+            "sha256": "1cfd5c2a14b50dadfa2798f23e051d172dcbf327cc928253123777de13332bf7",
+            "area": "tool",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/tool_offload_middleware_test.py",
+            "sha256": "9bcc9cc4e7b0070823538567ed0c9ec0705086682bca79132dde9a0f0f982426",
+            "area": "tool",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/toolkit_skill_test.py",
+            "sha256": "55544a87af9f795b5eef816a5a9fe397d96ba82031e81526b65556f473d850db",
+            "area": "toolkit",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/toolkit_task_test.py",
+            "sha256": "97c53e79a723af816dc4b2d741c67bc9ff80d8e70f1bf31f8192685beaae27ec",
+            "area": "toolkit",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/toolkit_test.py",
+            "sha256": "e67add9e08c30b0d096d92927ec346ac1a8e9871c7ffeaaf3ce8658ca5887f30",
+            "area": "toolkit",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/tracing_test.py",
+            "sha256": "228d4ce0b5c72f0674f0a370034d97525efd8fea073a4d4970d8c5d354864fb3",
+            "area": "tracing",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/tts_dashscope_test.py",
+            "sha256": "d00ef408e8be607a517c3549ec3aeb06b0a7311778ea2775e770767ca7c02723",
+            "area": "tts",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/tts_gemini_test.py",
+            "sha256": "aeef85130d71a68275de557123a5283143dd11ccfd3ed30b50dc21cb8bc94fe9",
+            "area": "tts",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/tts_middleware_test.py",
+            "sha256": "49b877cfc77259654f36d27ba22b80752b958b60e3f28e5e83176b4ac7331015",
+            "area": "tts",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/tts_openai_test.py",
+            "sha256": "881799e77ed8fd9cdf9e062fa2b31bc1aae7959fadda28bceaf5444905dadfa4",
+            "area": "tts",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/utils.py",
+            "sha256": "0e19fd79b35caf2b643e05c54db92499441187483670976c4a594545da8a55b1",
+            "area": "utils",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/workspace_applecontainer_test.py",
+            "sha256": "99864c65a23ee89caf4241a7ec6402afae36b4065ce9d68d5651d605ed8a73ae",
+            "area": "workspace",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/workspace_bubblewrap_test.py",
+            "sha256": "31774c3906614aa73f6bcf84bee8ba1fad13fb84fff0e75529d2fba4a3f7a851",
+            "area": "workspace",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/workspace_daytona_test.py",
+            "sha256": "5a369c89d91425af617593a97093ebf699c9268b311ce8dc1e0f635073fe6091",
+            "area": "workspace",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/workspace_docker_test.py",
+            "sha256": "2c9ee63efbe98531a61eb1a6341d1d6158f0b78f8f087c15e7133f6225c85ffd",
+            "area": "workspace",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/workspace_e2b_test.py",
+            "sha256": "cd68230f4db8a9d515ae7c8c27b0e27ed6d5fc8342ad864d78b2727308350d4c",
+            "area": "workspace",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/workspace_k8s_test.py",
+            "sha256": "d3364fc140b9ae16e152e1e76e8aa04fe3abe7ff8cbf16b4c7a65b3a07060d5d",
+            "area": "workspace",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/workspace_local_test.py",
+            "sha256": "2a67442ded9ca8e1ed5d8a4321073ba7e05b68c639af8d43c1d8e63fa027c0b1",
+            "area": "workspace",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/workspace_manager_applecontainer_test.py",
+            "sha256": "0421d3e2ab587ea1dd67462694c6396c292da731927ebc7b4233e2c3da5a8dd8",
+            "area": "workspace",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/workspace_manager_daytona_test.py",
+            "sha256": "5b9c810f62ee23305f2c2affc0e0cc3e4a15de398072727b98708354e450279d",
+            "area": "workspace",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/workspace_manager_docker_test.py",
+            "sha256": "5b74713a5d9c46a441b5c8302faf2cfbfaed2723fb52e9fd155147af73e2785d",
+            "area": "workspace",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/workspace_manager_e2b_test.py",
+            "sha256": "6081786171c2756e5db40de67502170ff6349282f56dcaa505deba9c3cfa5478",
+            "area": "workspace",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/workspace_manager_local_test.py",
+            "sha256": "d7135ce3d4ec77fe1a1d65dc251abda94ddf40586bc61f5f22fd472483211184",
+            "area": "workspace",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/workspace_opensandbox_test.py",
+            "sha256": "2a1ddef6d4e6aa1a8bb49ddd93e5614b4a34b276bfdbe9911de766a9f829d238",
+            "area": "workspace",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/workspace_prewarm_test.py",
+            "sha256": "c3e554730d9625c22b88ff1e55790ca6644bef473724656fa6f66413e4f42774",
+            "area": "workspace",
+            "typescriptTests": []
+        },
+        {
+            "path": "tests/workspace_skill_archive_test.py",
+            "sha256": "c3b09412c2028a4071c604322b59efc3b878eb6b71664a8c54455846b2eb0999",
+            "area": "workspace",
+            "typescriptTests": []
+        }
+    ],
+    "summary": {
+        "sourceFiles": {
+            "count": 429,
+            "sha256": "b078bcd1147218017fa6c193b14c5f970aacc5de3335490c5b84652a87e00724"
+        },
+        "contractDataFiles": {
+            "count": 104,
+            "sha256": "f111c377ab534a0540f754886d7226a1d8bd68bdb6a3e4443e8cd0178e2d50a8"
+        },
+        "testFiles": {
+            "count": 160,
+            "sha256": "ae02b93ab918da4b93c2b40af5bcfdb70c38751ed5953524944177e62f00a76b"
+        }
+    }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,9 +1,9 @@
 packages:
-  - 'packages/*'
-  - 'apps/*'
+    - 'packages/*'
+    - 'apps/*'
 allowBuilds:
-  electron: true
-  electron-winstaller: true
-  esbuild: true
-  typeit: true
-  unrs-resolver: true
+    electron: true
+    electron-winstaller: true
+    esbuild: true
+    typeit: true
+    unrs-resolver: true

--- a/scripts/parity/check-manifest.mjs
+++ b/scripts/parity/check-manifest.mjs
@@ -1,0 +1,103 @@
+import { execFileSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describeFiles, hashFileSet, validateManifest, walkFiles } from './manifest-lib.mjs';
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, '../..');
+
+/**
+ * Read an optional CLI argument.
+ *
+ * @param {string} name Option name.
+ * @returns {string | undefined} Option value.
+ */
+function readOption(name) {
+    const index = process.argv.indexOf(name);
+    return index === -1 ? undefined : process.argv[index + 1];
+}
+
+/**
+ * Compare manifest entries with files from the Python checkout.
+ *
+ * @param {object} manifest Parsed manifest.
+ * @param {string} pythonRoot Python repository root.
+ * @returns {Promise<string[]>} Verification errors.
+ */
+async function verifyPythonCheckout(manifest, pythonRoot) {
+    const errors = [];
+    const commit = execFileSync('git', ['-C', pythonRoot, 'rev-parse', 'HEAD'], {
+        encoding: 'utf8',
+    }).trim();
+    if (commit !== manifest.pythonCommit) {
+        errors.push(`Python checkout is ${commit}, expected ${manifest.pythonCommit}.`);
+    }
+
+    const allSourcePaths = await walkFiles(path.join(pythonRoot, 'src/agentscope'));
+    const collections = [
+        {
+            name: 'sourceFiles',
+            paths: allSourcePaths.filter(filePath => !filePath.endsWith('.yaml')),
+        },
+        {
+            name: 'contractDataFiles',
+            paths: allSourcePaths.filter(filePath => filePath.endsWith('.yaml')),
+        },
+        {
+            name: 'testFiles',
+            paths: await walkFiles(path.join(pythonRoot, 'tests')),
+        },
+    ];
+
+    for (const collection of collections) {
+        const actualFiles = await describeFiles(pythonRoot, collection.paths);
+        const actualByPath = new Map(actualFiles.map(file => [file.path, file.sha256]));
+        const expectedEntries = manifest[collection.name];
+        const expectedByPath = new Map(expectedEntries.map(entry => [entry.path, entry.sha256]));
+
+        for (const [filePath, digest] of actualByPath) {
+            if (!expectedByPath.has(filePath)) {
+                errors.push(`${collection.name} is missing ${filePath}.`);
+            } else if (expectedByPath.get(filePath) !== digest) {
+                errors.push(`${collection.name} digest mismatch for ${filePath}.`);
+            }
+        }
+        for (const filePath of expectedByPath.keys()) {
+            if (!actualByPath.has(filePath)) {
+                errors.push(`${collection.name} contains stale path ${filePath}.`);
+            }
+        }
+
+        const aggregateDigest = hashFileSet(actualFiles);
+        if (aggregateDigest !== manifest.summary[collection.name].sha256) {
+            errors.push(`${collection.name} aggregate digest mismatch.`);
+        }
+    }
+
+    return errors;
+}
+
+const manifestPath = path.resolve(
+    readOption('--manifest') ?? path.join(repositoryRoot, 'parity/agentscope-python-de163b34.json')
+);
+const pythonRootOption = readOption('--python-root');
+const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+const errors = validateManifest(manifest);
+
+if (pythonRootOption) {
+    errors.push(...(await verifyPythonCheckout(manifest, path.resolve(pythonRootOption))));
+}
+
+if (errors.length > 0) {
+    process.stderr.write(`${errors.join('\n')}\n`);
+    process.exitCode = 1;
+} else {
+    process.stdout.write(
+        `Parity manifest is valid for ${manifest.pythonCommit}: ` +
+            `${manifest.sourceFiles.length} source files, ` +
+            `${manifest.contractDataFiles.length} contract data files, ` +
+            `${manifest.testFiles.length} test files.\n`
+    );
+}

--- a/scripts/parity/generate-manifest.mjs
+++ b/scripts/parity/generate-manifest.mjs
@@ -1,0 +1,112 @@
+import { execFileSync } from 'node:child_process';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { format, resolveConfig } from 'prettier';
+
+import {
+    describeFiles,
+    hashFileSet,
+    sourceModule,
+    testArea,
+    typescriptTarget,
+    validateManifest,
+    walkFiles,
+} from './manifest-lib.mjs';
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, '../..');
+
+/**
+ * Read a named CLI option.
+ *
+ * @param {string} name Option name.
+ * @param {string} fallback Default value.
+ * @returns {string} Option value.
+ */
+function readOption(name, fallback) {
+    const index = process.argv.indexOf(name);
+    return index === -1 ? fallback : process.argv[index + 1];
+}
+
+const pythonRoot = path.resolve(
+    readOption('--python-root', path.join(repositoryRoot, '../agentscope-python'))
+);
+const outputPath = path.resolve(
+    readOption('--output', path.join(repositoryRoot, 'parity/agentscope-python-de163b34.json'))
+);
+
+const pythonCommit = execFileSync('git', ['-C', pythonRoot, 'rev-parse', 'HEAD'], {
+    encoding: 'utf8',
+}).trim();
+
+const allSourcePaths = await walkFiles(path.join(pythonRoot, 'src/agentscope'));
+const contractDataPaths = allSourcePaths.filter(filePath => filePath.endsWith('.yaml'));
+const sourcePaths = allSourcePaths.filter(filePath => !filePath.endsWith('.yaml'));
+const testPaths = await walkFiles(path.join(pythonRoot, 'tests'));
+
+const sourceFiles = await describeFiles(pythonRoot, sourcePaths);
+const contractDataFiles = await describeFiles(pythonRoot, contractDataPaths);
+const testFiles = await describeFiles(pythonRoot, testPaths);
+
+const manifest = {
+    schemaVersion: 1,
+    pythonRepository: 'https://github.com/agentscope-ai/agentscope.git',
+    pythonCommit,
+    sourceFiles: sourceFiles.map(({ path: sourcePath, sha256 }) => ({
+        path: sourcePath,
+        sha256,
+        module: sourceModule(sourcePath),
+        typescriptTarget: typescriptTarget(sourcePath),
+        status: 'mapped',
+        pythonTests: [],
+        typescriptTests: [],
+    })),
+    contractDataFiles: contractDataFiles.map(({ path: sourcePath, sha256 }) => ({
+        path: sourcePath,
+        sha256,
+        module: sourceModule(sourcePath),
+        typescriptTarget: typescriptTarget(sourcePath),
+        status: 'mapped',
+    })),
+    testFiles: testFiles.map(({ path: testPath, sha256 }) => ({
+        path: testPath,
+        sha256,
+        area: testArea(testPath),
+        typescriptTests: [],
+    })),
+    summary: {
+        sourceFiles: {
+            count: sourceFiles.length,
+            sha256: hashFileSet(sourceFiles),
+        },
+        contractDataFiles: {
+            count: contractDataFiles.length,
+            sha256: hashFileSet(contractDataFiles),
+        },
+        testFiles: {
+            count: testFiles.length,
+            sha256: hashFileSet(testFiles),
+        },
+    },
+};
+
+const errors = validateManifest(manifest);
+if (errors.length > 0) {
+    throw new Error(`Generated manifest is invalid:\n${errors.join('\n')}`);
+}
+
+await mkdir(path.dirname(outputPath), { recursive: true });
+const prettierOptions = (await resolveConfig(outputPath)) ?? {};
+const manifestContent = await format(JSON.stringify(manifest), {
+    ...prettierOptions,
+    parser: 'json',
+});
+await writeFile(outputPath, manifestContent, 'utf8');
+
+process.stdout.write(
+    `Generated ${path.relative(repositoryRoot, outputPath)} for ${pythonCommit}: ` +
+        `${sourceFiles.length} source files, ${contractDataFiles.length} contract data files, ` +
+        `${testFiles.length} test files.\n`
+);

--- a/scripts/parity/manifest-lib.mjs
+++ b/scripts/parity/manifest-lib.mjs
@@ -1,0 +1,244 @@
+import { createHash } from 'node:crypto';
+import { readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+
+export const ALLOWED_STATUSES = new Set(['mapped', 'contracted', 'implemented', 'verified']);
+
+const CORE_ROOT = 'packages/agentscope/src';
+const SERVICE_ROOT = 'packages/agentscope-service/src';
+
+/**
+ * Return all files below a directory in stable path order.
+ *
+ * @param {string} directory Directory to traverse.
+ * @returns {Promise<string[]>} Absolute file paths.
+ */
+export async function walkFiles(directory) {
+    const entries = await readdir(directory, { withFileTypes: true });
+    const files = [];
+
+    for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+        const entryPath = path.join(directory, entry.name);
+        if (entry.isDirectory()) {
+            files.push(...(await walkFiles(entryPath)));
+        } else if (entry.isFile()) {
+            files.push(entryPath);
+        }
+    }
+
+    return files;
+}
+
+/**
+ * Calculate a SHA-256 digest for a buffer.
+ *
+ * @param {Buffer} content File content.
+ * @returns {string} Hex digest.
+ */
+export function hashContent(content) {
+    return createHash('sha256').update(content).digest('hex');
+}
+
+/**
+ * Calculate a stable aggregate digest from path/content pairs.
+ *
+ * @param {{ path: string; content: Buffer }[]} files Files to hash.
+ * @returns {string} Hex digest.
+ */
+export function hashFileSet(files) {
+    const digest = createHash('sha256');
+    const sortedFiles = [...files].sort((left, right) => left.path.localeCompare(right.path));
+
+    for (const file of sortedFiles) {
+        digest.update(file.path);
+        digest.update('\0');
+        digest.update(file.content);
+    }
+
+    return digest.digest('hex');
+}
+
+/**
+ * Convert an operating-system path to a repository path.
+ *
+ * @param {string} value Path to normalize.
+ * @returns {string} POSIX-style path.
+ */
+export function toRepositoryPath(value) {
+    return value.split(path.sep).join('/');
+}
+
+/**
+ * Resolve a Python source file to its logical module.
+ *
+ * @param {string} sourcePath Repository-relative source path.
+ * @returns {string} Python module group.
+ */
+export function sourceModule(sourcePath) {
+    const relativePath = sourcePath.replace(/^src\/agentscope\/?/, '');
+    if (!relativePath.includes('/')) {
+        return 'root';
+    }
+    const firstPart = relativePath.split('/')[0];
+
+    if (!firstPart) {
+        return 'root';
+    }
+
+    return firstPart;
+}
+
+/**
+ * Map a Python source file to its planned TypeScript implementation area.
+ *
+ * @param {string} sourcePath Repository-relative source path.
+ * @returns {string} TypeScript target directory or file.
+ */
+export function typescriptTarget(sourcePath) {
+    const relativePath = sourcePath.replace(/^src\/agentscope\/?/, '');
+    const parts = relativePath.split('/');
+    const firstPart = parts[0];
+
+    if (firstPart === 'app') {
+        const appPath = parts.slice(1, -1).join('/').replaceAll('_', '-');
+        return appPath ? `${SERVICE_ROOT}/${appPath}` : SERVICE_ROOT;
+    }
+
+    if (firstPart === '__init__.py') {
+        return `${CORE_ROOT}/index.ts`;
+    }
+
+    if (firstPart === '_logging.py') {
+        return `${CORE_ROOT}/logger`;
+    }
+
+    if (firstPart === '_version.py') {
+        return `${CORE_ROOT}/version.ts`;
+    }
+
+    if (!relativePath.includes('/')) {
+        return 'packages/agentscope';
+    }
+
+    const moduleName = firstPart.replace(/^_/, '').replaceAll('_', '-').replace(/\.py$/, '');
+    return `${CORE_ROOT}/${moduleName}`;
+}
+
+/**
+ * Infer the broad behavior area represented by a Python test file.
+ *
+ * @param {string} testPath Repository-relative test path.
+ * @returns {string} Behavior area.
+ */
+export function testArea(testPath) {
+    const filename = path.posix.basename(testPath).replace(/\.py$/, '');
+    const normalized = filename.replace(/^test_/, '').replace(/_test$/, '');
+    return normalized.split('_')[0] || 'root';
+}
+
+/**
+ * Read and describe selected files relative to a repository root.
+ *
+ * @param {string} repositoryRoot Python repository root.
+ * @param {string[]} absolutePaths Files to describe.
+ * @returns {Promise<{ path: string; sha256: string; content: Buffer }[]>} File descriptions.
+ */
+export async function describeFiles(repositoryRoot, absolutePaths) {
+    return Promise.all(
+        absolutePaths.map(async filePath => {
+            const content = await readFile(filePath);
+            return {
+                path: toRepositoryPath(path.relative(repositoryRoot, filePath)),
+                sha256: hashContent(content),
+                content,
+            };
+        })
+    );
+}
+
+/**
+ * Validate the static structure and invariants of a parity manifest.
+ *
+ * @param {unknown} value Parsed manifest value.
+ * @returns {string[]} Validation errors.
+ */
+export function validateManifest(value) {
+    const errors = [];
+    if (!value || typeof value !== 'object') {
+        return ['Manifest must be an object.'];
+    }
+
+    const manifest = value;
+    if (manifest.schemaVersion !== 1) {
+        errors.push('schemaVersion must be 1.');
+    }
+    if (!/^[0-9a-f]{40}$/.test(manifest.pythonCommit ?? '')) {
+        errors.push('pythonCommit must be a full Git SHA.');
+    }
+
+    const collections = [
+        ['sourceFiles', manifest.sourceFiles],
+        ['contractDataFiles', manifest.contractDataFiles],
+        ['testFiles', manifest.testFiles],
+    ];
+
+    for (const [name, entries] of collections) {
+        if (!Array.isArray(entries)) {
+            errors.push(`${name} must be an array.`);
+            continue;
+        }
+
+        const paths = new Set();
+        for (const entry of entries) {
+            if (!entry || typeof entry !== 'object') {
+                errors.push(`${name} contains a non-object entry.`);
+                continue;
+            }
+            if (typeof entry.path !== 'string' || !entry.path) {
+                errors.push(`${name} contains an entry without a path.`);
+            } else if (paths.has(entry.path)) {
+                errors.push(`${name} contains duplicate path ${entry.path}.`);
+            } else {
+                paths.add(entry.path);
+            }
+            if (!/^[0-9a-f]{64}$/.test(entry.sha256 ?? '')) {
+                errors.push(`${name} contains an invalid digest for ${entry.path ?? '<unknown>'}.`);
+            }
+        }
+    }
+
+    for (const entry of [
+        ...(Array.isArray(manifest.sourceFiles) ? manifest.sourceFiles : []),
+        ...(Array.isArray(manifest.contractDataFiles) ? manifest.contractDataFiles : []),
+    ]) {
+        if (!ALLOWED_STATUSES.has(entry.status)) {
+            errors.push(`Invalid parity status ${entry.status} for ${entry.path}.`);
+        }
+        if (typeof entry.typescriptTarget !== 'string' || !entry.typescriptTarget) {
+            errors.push(`Missing TypeScript target for ${entry.path}.`);
+        }
+    }
+
+    const summary = manifest.summary;
+    if (!summary || typeof summary !== 'object') {
+        errors.push('summary must be an object.');
+    } else {
+        const expectedCounts = {
+            sourceFiles: Array.isArray(manifest.sourceFiles) ? manifest.sourceFiles.length : 0,
+            contractDataFiles: Array.isArray(manifest.contractDataFiles)
+                ? manifest.contractDataFiles.length
+                : 0,
+            testFiles: Array.isArray(manifest.testFiles) ? manifest.testFiles.length : 0,
+        };
+        for (const [name, count] of Object.entries(expectedCounts)) {
+            if (summary[name]?.count !== count) {
+                errors.push(`summary.${name}.count must equal ${count}.`);
+            }
+            if (!/^[0-9a-f]{64}$/.test(summary[name]?.sha256 ?? '')) {
+                errors.push(`summary.${name}.sha256 must be a SHA-256 digest.`);
+            }
+        }
+    }
+
+    return errors;
+}

--- a/scripts/parity/manifest-lib.test.mjs
+++ b/scripts/parity/manifest-lib.test.mjs
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+    hashFileSet,
+    sourceModule,
+    testArea,
+    typescriptTarget,
+    validateManifest,
+} from './manifest-lib.mjs';
+
+test('maps core and service source paths', () => {
+    assert.equal(sourceModule('src/agentscope/message/_base.py'), 'message');
+    assert.equal(
+        typescriptTarget('src/agentscope/message/_base.py'),
+        'packages/agentscope/src/message'
+    );
+    assert.equal(
+        typescriptTarget('src/agentscope/app/message_bus/_base.py'),
+        'packages/agentscope-service/src/message-bus'
+    );
+    assert.equal(typescriptTarget('src/agentscope/_logging.py'), 'packages/agentscope/src/logger');
+    assert.equal(sourceModule('src/agentscope/py.typed'), 'root');
+    assert.equal(typescriptTarget('src/agentscope/py.typed'), 'packages/agentscope');
+    assert.equal(
+        typescriptTarget('src/agentscope/workspace/_docker/Dockerfile.template'),
+        'packages/agentscope/src/workspace'
+    );
+});
+
+test('infers behavior areas from both Python test naming conventions', () => {
+    assert.equal(testArea('tests/agent_basic_test.py'), 'agent');
+    assert.equal(testArea('tests/test_e2e_api.py'), 'e2e');
+});
+
+test('aggregate hashing is independent of input order', () => {
+    const first = { path: 'a.py', content: Buffer.from('a') };
+    const second = { path: 'b.py', content: Buffer.from('b') };
+    assert.equal(hashFileSet([first, second]), hashFileSet([second, first]));
+});
+
+test('validates complete manifest structure', () => {
+    const digest = '0'.repeat(64);
+    const manifest = {
+        schemaVersion: 1,
+        pythonCommit: '0'.repeat(40),
+        sourceFiles: [
+            {
+                path: 'src/agentscope/message/_base.py',
+                sha256: digest,
+                status: 'mapped',
+                typescriptTarget: 'packages/agentscope/src/message',
+            },
+        ],
+        contractDataFiles: [],
+        testFiles: [],
+        summary: {
+            sourceFiles: { count: 1, sha256: digest },
+            contractDataFiles: { count: 0, sha256: digest },
+            testFiles: { count: 0, sha256: digest },
+        },
+    };
+
+    assert.deepEqual(validateManifest(manifest), []);
+});
+
+test('rejects duplicate paths and unsupported statuses', () => {
+    const digest = '0'.repeat(64);
+    const manifest = {
+        schemaVersion: 1,
+        pythonCommit: '0'.repeat(40),
+        sourceFiles: [
+            {
+                path: 'same.py',
+                sha256: digest,
+                status: 'skipped',
+                typescriptTarget: 'target',
+            },
+            {
+                path: 'same.py',
+                sha256: digest,
+                status: 'mapped',
+                typescriptTarget: 'target',
+            },
+        ],
+        contractDataFiles: [],
+        testFiles: [],
+        summary: {
+            sourceFiles: { count: 2, sha256: digest },
+            contractDataFiles: { count: 0, sha256: digest },
+            testFiles: { count: 0, sha256: digest },
+        },
+    };
+
+    assert.deepEqual(validateManifest(manifest), [
+        'sourceFiles contains duplicate path same.py.',
+        'Invalid parity status skipped for same.py.',
+    ]);
+});


### PR DESCRIPTION
## Linked Issues

- Related to #49

## Description

### Background and purpose

The incremental parity rollout needs a reproducible inventory before runtime PRs begin. This independent Phase 0 PR pins the Python source baseline and makes later module coverage auditable.

### Changes

- Pin AgentScope Python commit `de163b34b909edaba3c174190ad7e1a355e7849f`.
- Add deterministic source, contract-data, and test inventory generation.
- Add input-order-independent aggregate SHA-256 digests.
- Validate manifest structure, file counts, duplicate paths, statuses, and the checked-out Python commit.
- Add focused tests for the manifest library.
- Add an isolated CI job that checks out Python and verifies the committed manifest.
- Document regeneration and verification in `parity/README.md`.

### Scope

This PR contains no runtime TypeScript changes, public APIs, provider/Agent/Service/Desktop implementations, or final Python `main` delta.

### Review guide

1. Review the five handwritten files under `scripts/parity/` and their tests.
2. Review `parity/README.md` for workflow and invariants.
3. Do not review the generated JSON line by line; reproduce it with `parity:generate` and verify it with `parity:check`.
4. Review the isolated `parity-manifest` CI job last.

The generated manifest accounts for most of this PR's line count.

### Verification

With the pinned Python repository checked out next to this repository:

```bash
npx --yes pnpm@9.15.9 install --frozen-lockfile
npx --yes pnpm@9.15.9 format
npx --yes pnpm@9.15.9 run test:parity
node scripts/parity/check-manifest.mjs --python-root ../agentscope-python
```

Local verification passed:

- 5 parity-tooling tests.
- Pinned-checkout manifest verification.
- Inventory of 429 Python source files, 104 contract-data files, and 160 Python test files.
- Frozen-lockfile installation.
- Formatting with no diff.

GitHub Actions passed on Ubuntu, macOS, and Windows, including the dedicated parity-manifest job.

### Dependency

- Base: `main`
- Depends on: none
- Can be reviewed independently from #50
- Full snapshot for reference only: `rayrayraykk:feat/parity-foundation`

## Checklist

- [x] This PR is linked to a related issue (see above)
- [x] Code has been formatted with `pnpm format`
- [x] Related documentation has been updated (`parity/README.md`)
- [x] All tests are passing (`pnpm test` and the focused commands above)
- [x] Code is ready for review
