### PR TITLE
feat(message): align message contracts with Python

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/agent-event-handler.ts
+++ b/apps/desktop/src/renderer/src/hooks/agent-event-handler.ts
@@ -21,18 +21,15 @@ export function applyAgentEvent(
                 if (existingMsg) {
                     // Already exists, mark as not finished
                     return prev.map(m =>
-                        m.id === event.reply_id ? { ...m, finished_at: undefined } : m
+                        m.id === event.reply_id ? { ...m, finished_at: null } : m
                     );
                 }
-                const newMsg: Msg = {
-                    ...createMsg({
-                        id: event.reply_id,
-                        role: event.role,
-                        name: event.name,
-                        content: [],
-                    }),
-                    finished_at: undefined,
-                };
+                const newMsg = createMsg({
+                    id: event.reply_id,
+                    role: event.role,
+                    name: event.name,
+                    content: [],
+                });
                 return [...prev, newMsg];
             });
             break;
@@ -58,17 +55,9 @@ export function applyAgentEvent(
             setMessages(prev =>
                 prev.map(m => {
                     if (m.id !== event.reply_id) return m;
-                    const currentUsage = m.usage || {
-                        input_tokens: 0,
-                        output_tokens: 0,
-                    };
-                    return {
-                        ...m,
-                        usage: {
-                            input_tokens: currentUsage.input_tokens + event.input_tokens,
-                            output_tokens: currentUsage.output_tokens + event.output_tokens,
-                        },
-                    };
+                    const cloned: Msg = { ...m, content: m.content.map(b => ({ ...b })) };
+                    appendEvent(cloned, event);
+                    return cloned;
                 })
             );
             break;

--- a/packages/agentscope/src/_utils/common.ts
+++ b/packages/agentscope/src/_utils/common.ts
@@ -3,6 +3,22 @@ import { jsonrepair } from 'jsonrepair';
 import { JSONSerializableObject } from '../type';
 
 /**
+ * Generate a Python-compatible entity identifier.
+ * @returns A UUID hex string.
+ */
+export function _generateId(): string {
+    return crypto.randomUUID().replaceAll('-', '');
+}
+
+/**
+ * Generate an ISO-8601 entity timestamp.
+ * @returns The current timestamp.
+ */
+export function _generateTimestamp(): string {
+    return new Date().toISOString();
+}
+
+/**
  * Decode a base64 string to a Uint8Array.
  * Works in both Node.js and browser environments.
  * @param b64

--- a/packages/agentscope/src/agent/agent.test.ts
+++ b/packages/agentscope/src/agent/agent.test.ts
@@ -147,6 +147,11 @@ describe('Human-in-the-loop', () => {
                 name: 'Friday',
                 role: 'assistant',
                 created_at: expect.any(String),
+                usage: null,
+                finished_at: null,
+                finished_reason: null,
+                structured_output: null,
+                error: null,
             },
         ]);
 
@@ -408,7 +413,11 @@ describe('Human-in-the-loop', () => {
                 name: 'Friday',
                 role: 'assistant',
                 created_at: expect.any(String),
-                finished_at: undefined,
+                usage: null,
+                finished_at: null,
+                finished_reason: null,
+                structured_output: null,
+                error: null,
             },
         ]);
 

--- a/packages/agentscope/src/agent/agent.ts
+++ b/packages/agentscope/src/agent/agent.ts
@@ -263,8 +263,13 @@ export class Agent {
      */
     protected _saveToContext(blocks: ContentBlock[], usage?: ChatUsage): void {
         const msgUsage: Msg['usage'] = usage
-            ? { input_tokens: usage.inputTokens, output_tokens: usage.outputTokens }
-            : undefined;
+            ? {
+                  input_tokens: usage.inputTokens,
+                  output_tokens: usage.outputTokens,
+                  cache_input_tokens: 0,
+                  cache_creation_input_tokens: 0,
+              }
+            : null;
         const lastMsg = this.context.at(-1);
         if (this.context.length === 0) {
             this.context.push(
@@ -282,6 +287,8 @@ export class Agent {
                     lastMsg.usage = {
                         input_tokens: 0,
                         output_tokens: 0,
+                        cache_input_tokens: 0,
+                        cache_creation_input_tokens: 0,
                     };
                 }
                 lastMsg.usage.input_tokens = lastMsg.usage.input_tokens + msgUsage.input_tokens;

--- a/packages/agentscope/src/event/index.ts
+++ b/packages/agentscope/src/event/index.ts
@@ -1,5 +1,9 @@
 import { DataBlock, TextBlock, ToolCallBlock, ToolResultBlock } from '../message';
 import { PermissionRule } from '../permission';
+import { ErrorInfo, ReplyFinishedReason } from '../type';
+
+export { ErrorType, ReplyFinishedReason } from '../type';
+export type { ErrorInfo } from '../type';
 
 export enum EventType {
     REPLY_START = 'REPLY_START',
@@ -56,47 +60,6 @@ export interface ReplyStartEvent extends EventBase {
     role: 'user' | 'assistant' | 'system';
 }
 
-/** The reason a reply finished. */
-export enum ReplyFinishedReason {
-    COMPLETED = 'completed',
-    INTERRUPTED = 'interrupted',
-    EXCEED_MAX_ITERS = 'exceed_max_iters',
-    ERROR = 'error',
-}
-
-/**
- * Classification of a fatal error that terminated a reply.
- *
- * Not model-specific: the status-derived members apply to any upstream
- * service reached during a reply (chat model, embedding, TTS, MCP).
- */
-export enum ErrorType {
-    /** 401 — credential missing or wrong. */
-    AUTHENTICATION = 'authentication',
-    /** 403 — authenticated but not allowed. */
-    PERMISSION = 'permission',
-    /** 429 — rate/quota exceeded. */
-    RATE_LIMIT = 'rate_limit',
-    /** 400 / 422 — malformed request. */
-    INVALID_REQUEST = 'invalid_request',
-    /** 5xx — an upstream service failed. */
-    UPSTREAM = 'upstream',
-    /** Network error / timeout — no HTTP status available. */
-    CONNECTION = 'connection',
-    /** Framework bug or otherwise unexpected exception. */
-    INTERNAL = 'internal',
-    /** Fallback when no better classification is possible. */
-    UNKNOWN = 'unknown',
-}
-
-/** Structured, UI-facing description of a fatal reply error. */
-export interface ErrorInfo {
-    /** Stable classification key; the frontend localizes off it. */
-    type: ErrorType;
-    /** Short, sanitized, human-readable description. */
-    message: string;
-}
-
 export interface ReplyEndEvent extends EventBase {
     type: EventType.REPLY_END;
     session_id: string;
@@ -121,6 +84,8 @@ export interface ModelCallEndEvent extends EventBase {
     reply_id: string;
     input_tokens: number;
     output_tokens: number;
+    cache_input_tokens?: number;
+    cache_creation_input_tokens?: number;
 }
 
 export interface TextBlockStartEvent extends EventBase {

--- a/packages/agentscope/src/message/append-event.test.ts
+++ b/packages/agentscope/src/message/append-event.test.ts
@@ -46,7 +46,12 @@ function ts(n: number): string {
  * @param finishedAt
  * @returns A text block object.
  */
-function tb(blockId: string, text: string, createdAt: string, finishedAt?: string): TextBlock {
+function tb(
+    blockId: string,
+    text: string,
+    createdAt: string,
+    finishedAt: string | null = null
+): TextBlock {
     return { type: 'text', id: blockId, text, created_at: createdAt, finished_at: finishedAt };
 }
 
@@ -62,7 +67,7 @@ function thb(
     blockId: string,
     thinking: string,
     createdAt: string,
-    finishedAt?: string
+    finishedAt: string | null = null
 ): ThinkingBlock {
     return {
         type: 'thinking',
@@ -87,12 +92,13 @@ function dbB64(
     data: string,
     mediaType: string,
     createdAt: string,
-    finishedAt?: string
+    finishedAt: string | null = null
 ): DataBlock {
     return {
         type: 'data',
         id: blockId,
         source: { type: 'base64', data, media_type: mediaType },
+        name: null,
         created_at: createdAt,
         finished_at: finishedAt,
     };
@@ -112,12 +118,13 @@ function dbUrl(
     url: string,
     mediaType: string,
     createdAt: string,
-    finishedAt?: string
+    finishedAt: string | null = null
 ): DataBlock {
     return {
         type: 'data',
         id: blockId,
         source: { type: 'url', url, media_type: mediaType },
+        name: null,
         created_at: createdAt,
         finished_at: finishedAt,
     };
@@ -140,8 +147,8 @@ function tcb(
     inp: string,
     state: ToolCallBlock['state'],
     createdAt: string,
-    finishedAt?: string,
-    suggestedRules?: PermissionRule[]
+    finishedAt: string | null = null,
+    suggestedRules: PermissionRule[] = []
 ): ToolCallBlock {
     const block: ToolCallBlock = {
         type: 'tool_call',
@@ -152,7 +159,7 @@ function tcb(
         created_at: createdAt,
         finished_at: finishedAt,
     };
-    if (suggestedRules !== undefined) block.suggested_rules = suggestedRules;
+    block.suggested_rules = suggestedRules;
     return block;
 }
 
@@ -172,7 +179,7 @@ function trb(
     output: ToolResultBlock['output'],
     state: ToolResultBlock['state'],
     createdAt: string,
-    finishedAt?: string
+    finishedAt: string | null = null
 ): ToolResultBlock {
     return {
         type: 'tool_result',
@@ -180,6 +187,7 @@ function trb(
         name,
         output,
         state,
+        metadata: {},
         created_at: createdAt,
         finished_at: finishedAt,
     };
@@ -190,6 +198,7 @@ describe('appendEvent', () => {
     let createdAt: string;
 
     beforeEach(() => {
+        jest.useFakeTimers().setSystemTime(new Date(ts(0)));
         msg = createMsg({
             id: REPLY_ID,
             name: 'TestAgent',
@@ -197,6 +206,10 @@ describe('appendEvent', () => {
             content: [],
         });
         createdAt = msg.created_at;
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
     });
 
     /**
@@ -513,6 +526,7 @@ describe('appendEvent', () => {
                             id: expect.any(String),
                             text: 'Found:',
                             created_at: ts(20),
+                            finished_at: null,
                         },
                     ],
                     'running',
@@ -541,6 +555,7 @@ describe('appendEvent', () => {
                             id: expect.any(String),
                             text: 'Found: 3 items',
                             created_at: ts(20),
+                            finished_at: null,
                         },
                     ],
                     'running',
@@ -575,6 +590,7 @@ describe('appendEvent', () => {
                             id: expect.any(String),
                             text: 'Found: 3 items',
                             created_at: ts(20),
+                            finished_at: null,
                         },
                     ],
                     'success',
@@ -596,6 +612,7 @@ describe('appendEvent', () => {
                         id: expect.any(String),
                         text: 'Found: 3 items',
                         created_at: ts(20),
+                        finished_at: null,
                     },
                 ],
                 'success',
@@ -707,7 +724,9 @@ describe('appendEvent', () => {
             name: 'run_code',
             output: 'output: hello',
             state: 'success',
+            metadata: {},
             created_at: EXT_RES_CREATED,
+            finished_at: null,
         };
         events.push({
             id: '30',
@@ -866,6 +885,7 @@ describe('appendEvent', () => {
         // Apply all events and check ground truths
         expect(events.length).toBe(groundTruths.length);
         for (let i = 0; i < events.length; i++) {
+            jest.setSystemTime(new Date(events[i].created_at));
             appendEvent(msg, events[i]);
             expect(msgDump(msg)).toEqual(groundTruths[i]);
         }
@@ -884,12 +904,49 @@ describe('appendEvent', () => {
         expect(msgDump(msg)).toEqual(original);
     });
 
+    test('MODEL_CALL_END initializes and accumulates all Python usage fields', () => {
+        appendEvent(msg, {
+            id: 'model-1',
+            created_at: ts(1),
+            type: EventType.MODEL_CALL_END,
+            reply_id: REPLY_ID,
+            input_tokens: 100,
+            output_tokens: 20,
+            cache_input_tokens: 60,
+            cache_creation_input_tokens: 10,
+        });
+        expect(msg.usage).toEqual({
+            input_tokens: 100,
+            output_tokens: 20,
+            cache_input_tokens: 60,
+            cache_creation_input_tokens: 10,
+        });
+
+        appendEvent(msg, {
+            id: 'model-2',
+            created_at: ts(2),
+            type: EventType.MODEL_CALL_END,
+            reply_id: REPLY_ID,
+            input_tokens: 25,
+            output_tokens: 5,
+            cache_input_tokens: 12,
+            cache_creation_input_tokens: 2,
+        });
+        expect(msg.usage).toEqual({
+            input_tokens: 125,
+            output_tokens: 25,
+            cache_input_tokens: 72,
+            cache_creation_input_tokens: 12,
+        });
+    });
+
     test('HINT_BLOCK one-shot event appends a complete HintBlock', () => {
         const HINT_ID_1 = 'h_001';
         const HINT_ID_2 = 'h_002';
 
         // String hint with source — created_at and finished_at both come
         // from the one-shot event's timestamp.
+        jest.setSystemTime(new Date(ts(1)));
         appendEvent(msg, {
             id: 'e1',
             created_at: ts(1),
@@ -920,6 +977,7 @@ describe('appendEvent', () => {
                 created_at: ts(2),
             },
         ];
+        jest.setSystemTime(new Date(ts(2)));
         appendEvent(msg, {
             id: 'e2',
             created_at: ts(2),

--- a/packages/agentscope/src/message/block.ts
+++ b/packages/agentscope/src/message/block.ts
@@ -1,4 +1,5 @@
-import { PermissionRule } from '../permission';
+import { _generateId, _generateTimestamp } from '../_utils/common';
+import type { PermissionRule } from '../permission';
 
 export interface TextBlock {
     type: 'text';
@@ -11,6 +12,7 @@ export interface TextBlock {
 }
 
 export interface ThinkingBlock {
+    [key: string]: unknown;
     type: 'thinking';
     thinking: string;
     id: string;
@@ -92,11 +94,160 @@ export interface DataBlock {
     type: 'data';
     source: Base64Source | URLSource;
     id: string;
-    name?: string;
+    name?: string | null;
     /** ISO-8601 creation timestamp of the block. */
     created_at: string;
     /** ISO-8601 finished timestamp of the block. */
     finished_at?: string | null;
+}
+
+type GeneratedBlockFields = 'type' | 'id' | 'created_at' | 'finished_at';
+
+/**
+ * Create a text block with the same defaults as Python's `TextBlock`.
+ * @param input
+ * @returns A normalized text block.
+ */
+export function TextBlock(
+    input: Omit<TextBlock, GeneratedBlockFields> &
+        Partial<Pick<TextBlock, 'id' | 'created_at' | 'finished_at'>>
+): TextBlock {
+    return {
+        type: 'text',
+        text: input.text,
+        id: input.id ?? _generateId(),
+        created_at: input.created_at ?? _generateTimestamp(),
+        finished_at: input.finished_at ?? null,
+    };
+}
+
+/**
+ * Create a thinking block while preserving provider-specific fields.
+ * @param input
+ * @param input.thinking
+ * @param input.id
+ * @param input.created_at
+ * @param input.finished_at
+ * @returns A normalized thinking block.
+ */
+export function ThinkingBlock(input: {
+    thinking: string;
+    id?: string;
+    created_at?: string;
+    finished_at?: string | null;
+    [key: string]: unknown;
+}): ThinkingBlock {
+    return {
+        ...input,
+        type: 'thinking',
+        thinking: input.thinking,
+        id: input.id ?? _generateId(),
+        created_at: input.created_at ?? _generateTimestamp(),
+        finished_at: input.finished_at ?? null,
+    };
+}
+
+/**
+ * Create an inline base64 data source.
+ * @param input
+ * @returns A normalized base64 source.
+ */
+export function Base64Source(input: Omit<Base64Source, 'type'>): Base64Source {
+    return { type: 'base64', data: input.data, media_type: input.media_type };
+}
+
+/**
+ * Create and validate a URL data source.
+ * @param input
+ * @returns A normalized URL source.
+ */
+export function URLSource(input: Omit<URLSource, 'type'>): URLSource {
+    const url = new URL(input.url).toString();
+    return { type: 'url', url, media_type: input.media_type };
+}
+
+/**
+ * Create a binary data block with Python-compatible defaults.
+ * @param input
+ * @returns A normalized data block.
+ */
+export function DataBlock(
+    input: Omit<DataBlock, GeneratedBlockFields | 'name'> &
+        Partial<Pick<DataBlock, 'id' | 'name' | 'created_at' | 'finished_at'>>
+): DataBlock {
+    return {
+        type: 'data',
+        id: input.id ?? _generateId(),
+        source: input.source,
+        name: input.name ?? null,
+        created_at: input.created_at ?? _generateTimestamp(),
+        finished_at: input.finished_at ?? null,
+    };
+}
+
+/**
+ * Create a one-shot hint block with Python-compatible defaults.
+ * @param input
+ * @returns A normalized hint block.
+ */
+export function HintBlock(
+    input: Omit<HintBlock, GeneratedBlockFields | 'source'> &
+        Partial<Pick<HintBlock, 'id' | 'source' | 'created_at' | 'finished_at'>>
+): HintBlock {
+    const createdAt = input.created_at ?? _generateTimestamp();
+    return {
+        type: 'hint',
+        hint: input.hint,
+        id: input.id ?? _generateId(),
+        source: input.source ?? null,
+        created_at: createdAt,
+        finished_at: input.finished_at === undefined ? _generateTimestamp() : input.finished_at,
+    };
+}
+
+/**
+ * Create a tool-call block with Python-compatible defaults.
+ * @param input
+ * @returns A normalized tool-call block.
+ */
+export function ToolCallBlock(
+    input: Omit<
+        ToolCallBlock,
+        'type' | 'state' | 'suggested_rules' | 'created_at' | 'finished_at'
+    > &
+        Partial<Pick<ToolCallBlock, 'state' | 'suggested_rules' | 'created_at' | 'finished_at'>>
+): ToolCallBlock {
+    return {
+        type: 'tool_call',
+        id: input.id,
+        name: input.name,
+        input: input.input,
+        state: input.state ?? 'pending',
+        suggested_rules: input.suggested_rules ?? [],
+        created_at: input.created_at ?? _generateTimestamp(),
+        finished_at: input.finished_at ?? null,
+    };
+}
+
+/**
+ * Create a tool-result block with Python-compatible defaults.
+ * @param input
+ * @returns A normalized tool-result block.
+ */
+export function ToolResultBlock(
+    input: Omit<ToolResultBlock, 'type' | 'state' | 'metadata' | 'created_at' | 'finished_at'> &
+        Partial<Pick<ToolResultBlock, 'state' | 'metadata' | 'created_at' | 'finished_at'>>
+): ToolResultBlock {
+    return {
+        type: 'tool_result',
+        id: input.id,
+        name: input.name,
+        output: input.output,
+        state: input.state ?? 'running',
+        metadata: input.metadata ?? {},
+        created_at: input.created_at ?? _generateTimestamp(),
+        finished_at: input.finished_at ?? null,
+    };
 }
 
 export type ContentBlock =
@@ -106,3 +257,8 @@ export type ContentBlock =
     | ToolCallBlock
     | ToolResultBlock
     | DataBlock;
+
+export type ContentBlockTypes = ContentBlock['type'];
+
+/** Idiomatic singular alias for a content block discriminator. */
+export type ContentBlockType = ContentBlockTypes;

--- a/packages/agentscope/src/message/index.ts
+++ b/packages/agentscope/src/message/index.ts
@@ -6,7 +6,9 @@ export {
     SystemMsg,
     getTextContent,
     getContentBlocks,
+    hasContentBlocks,
     appendEvent,
+    Usage,
 } from './message';
 export {
     TextBlock,
@@ -17,8 +19,26 @@ export {
     ToolResultBlock,
     ToolResultState,
     ContentBlock,
+    ContentBlockType,
+    ContentBlockTypes,
     Base64Source,
     URLSource,
     DataBlock,
 } from './block';
 export { GenerateReason } from './enums';
+export {
+    TextBlockSchema,
+    ThinkingBlockSchema,
+    Base64SourceSchema,
+    URLSourceSchema,
+    DataSourceSchema,
+    DataBlockSchema,
+    HintBlockSchema,
+    ToolCallBlockSchema,
+    ToolResultBlockSchema,
+    ContentBlockSchema,
+    UsageSchema,
+    MsgSchema,
+    parseContentBlock,
+    parseMsg,
+} from './schema';

--- a/packages/agentscope/src/message/message.test.ts
+++ b/packages/agentscope/src/message/message.test.ts
@@ -1,4 +1,6 @@
-import { createMsg, getContentBlocks, getTextContent } from './message';
+import { ErrorType } from '../type';
+import { createMsg, getContentBlocks, getTextContent, hasContentBlocks } from './message';
+import { parseMsg } from './schema';
 
 const TS = '2024-01-01T00:00:00.000Z';
 
@@ -19,7 +21,15 @@ describe('Message', () => {
         expect(msg.metadata).toEqual({});
         expect(msg.created_at).toBeDefined();
         expect(msg.id).toBeDefined();
+        expect(msg).toMatchObject({
+            usage: null,
+            finished_at: null,
+            finished_reason: null,
+            structured_output: null,
+            error: null,
+        });
         expect(getTextContent(msg)).toBe('Hello, world!');
+        expect(hasContentBlocks(msg, 'text')).toBe(true);
 
         // getContentBlocks wraps a string content into a single TextBlock
         const blocks = getContentBlocks(msg);
@@ -86,5 +96,44 @@ describe('Message', () => {
             },
         ]);
         expect(getContentBlocks(msg, 'data')).toStrictEqual([]);
+    });
+
+    test('parse a serialized message with Python defaults', () => {
+        const msg = parseMsg({
+            id: 'message-id',
+            name: 'assistant',
+            role: 'assistant',
+            content: [{ type: 'text', id: 'block-id', text: 'Hello', created_at: TS }],
+            created_at: TS,
+            usage: { input_tokens: 3, output_tokens: 2 },
+            error: { message: 'failed' },
+        });
+
+        expect(msg).toEqual({
+            id: 'message-id',
+            name: 'assistant',
+            role: 'assistant',
+            content: [
+                {
+                    type: 'text',
+                    id: 'block-id',
+                    text: 'Hello',
+                    created_at: TS,
+                    finished_at: null,
+                },
+            ],
+            metadata: {},
+            created_at: TS,
+            usage: {
+                input_tokens: 3,
+                output_tokens: 2,
+                cache_input_tokens: 0,
+                cache_creation_input_tokens: 0,
+            },
+            finished_at: null,
+            finished_reason: null,
+            structured_output: null,
+            error: { type: ErrorType.UNKNOWN, message: 'failed' },
+        });
     });
 });

--- a/packages/agentscope/src/message/message.ts
+++ b/packages/agentscope/src/message/message.ts
@@ -1,4 +1,4 @@
-import { JSONSerializableObject } from '../type';
+import type { JSONSerializableObject } from '../type';
 import {
     ContentBlock,
     TextBlock,
@@ -9,9 +9,11 @@ import {
     HintBlock,
     Base64Source,
     URLSource,
+    ContentBlockType,
 } from './block';
-import { base64ToBytes, bytesToBase64 } from '../_utils/common';
-import { AgentEvent, EventType, ReplyFinishedReason, ErrorInfo } from '../event';
+import { _generateId, _generateTimestamp, base64ToBytes, bytesToBase64 } from '../_utils/common';
+import { EventType, ReplyFinishedReason } from '../event';
+import type { AgentEvent, ErrorInfo } from '../event';
 
 /** A chat message exchanged between agents or between an agent and a model. */
 export interface Msg {
@@ -28,21 +30,45 @@ export interface Msg {
     /** ISO-8601 creation timestamp. */
     created_at: string;
     /** ISO-8601 finished timestamp. */
-    finished_at?: string | null;
+    finished_at: string | null;
     /**
      * Terminal reason of this reply (error / interrupted / exceed_max_iters).
      * Undefined/null until a REPLY_END event is applied.
      */
-    finished_reason?: ReplyFinishedReason | null;
+    finished_reason: ReplyFinishedReason | null;
+    /** Structured response payload, when requested and successfully generated. */
+    structured_output: Record<string, JSONSerializableObject> | null;
     /**
      * Structured error info, populated only when
      * `finished_reason === ReplyFinishedReason.ERROR`.
      */
-    error?: ErrorInfo | null;
+    error: ErrorInfo | null;
     /** Usage information for the message, such as token counts. */
-    usage?: {
-        input_tokens: number;
-        output_tokens: number;
+    usage: Usage | null;
+}
+
+/** Token usage stored on a message. */
+export interface Usage {
+    input_tokens: number;
+    output_tokens: number;
+    cache_input_tokens: number;
+    cache_creation_input_tokens: number;
+}
+
+type UsageInput = Pick<Usage, 'input_tokens' | 'output_tokens'> & Partial<Usage>;
+
+/**
+ * Normalize optional cache-token counters in usage input.
+ * @param usage
+ * @returns Normalized usage, or `null` when absent.
+ */
+function normalizeUsage(usage: UsageInput | null | undefined): Usage | null {
+    if (usage == null) return null;
+    return {
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        cache_input_tokens: usage.cache_input_tokens ?? 0,
+        cache_creation_input_tokens: usage.cache_creation_input_tokens ?? 0,
     };
 }
 
@@ -96,6 +122,9 @@ function assertContentBlocksForRole(role: Msg['role'], content: ContentBlock[]):
  * @param root0.created_at
  * @param root0.finished_at
  * @param root0.usage
+ * @param root0.finished_reason
+ * @param root0.structured_output
+ * @param root0.error
  * @returns A Msg object with the specified properties, and defaults for any omitted fields.
  */
 export function createMsg({
@@ -103,27 +132,42 @@ export function createMsg({
     content,
     role,
     metadata = {},
-    id = crypto.randomUUID(),
-    created_at = new Date().toISOString(),
-    finished_at,
+    id = _generateId(),
+    created_at = _generateTimestamp(),
+    finished_at = null,
+    finished_reason = null,
+    structured_output = null,
+    error = null,
     usage,
-}: Omit<Msg, 'id' | 'created_at' | 'metadata' | 'content'> &
-    Partial<Pick<Msg, 'id' | 'created_at' | 'metadata'>> & {
-        content: string | ContentBlock[];
-    }): Msg {
+}: {
+    name: string;
+    content: string | ContentBlock[];
+    role: Msg['role'];
+    metadata?: Msg['metadata'];
+    id?: string;
+    created_at?: string;
+    usage?: UsageInput | null;
+    finished_at?: string | null;
+    finished_reason?: ReplyFinishedReason | null;
+    structured_output?: Msg['structured_output'];
+    error?: ErrorInfo | null;
+}): Msg {
     const contentBlocks: ContentBlock[] =
-        typeof content === 'string'
-            ? [
-                  {
-                      id: crypto.randomUUID(),
-                      type: 'text',
-                      text: content,
-                      created_at: new Date().toISOString(),
-                  } as TextBlock,
-              ]
-            : content;
+        typeof content === 'string' ? [TextBlock({ text: content })] : content;
     assertContentBlocksForRole(role, contentBlocks);
-    return { id, name, role, content: contentBlocks, metadata, created_at, finished_at, usage };
+    return {
+        id,
+        name,
+        role,
+        content: contentBlocks,
+        metadata,
+        created_at,
+        usage: normalizeUsage(usage),
+        finished_at,
+        finished_reason,
+        structured_output,
+        error,
+    };
 }
 
 /**
@@ -135,31 +179,36 @@ export function createMsg({
  * @param root0.id
  * @param root0.created_at
  * @param root0.finished_at
+ * @param root0.finished_reason
  * @returns A Msg object with role 'user'.
  */
 export function UserMsg({
     name,
     content,
-    metadata = {},
-    id = crypto.randomUUID(),
-    created_at = new Date().toISOString(),
+    metadata,
+    id,
+    created_at,
     finished_at,
+    finished_reason,
 }: {
     name: string;
     content: string | ContentBlock[];
-    metadata?: Record<string, JSONSerializableObject>;
-    id?: string;
-    created_at?: string;
+    metadata?: Record<string, JSONSerializableObject> | null;
+    id?: string | null;
+    created_at?: string | null;
     finished_at?: string | null;
+    finished_reason?: ReplyFinishedReason | null;
 }): Msg {
+    const actualCreatedAt = created_at || _generateTimestamp();
     return createMsg({
         name,
         content,
         role: 'user',
-        metadata,
-        id,
-        created_at,
-        finished_at: finished_at ?? created_at,
+        metadata: metadata ?? {},
+        id: id || _generateId(),
+        created_at: actualCreatedAt,
+        finished_at: finished_at ?? actualCreatedAt,
+        finished_reason,
     });
 }
 
@@ -172,24 +221,44 @@ export function UserMsg({
  * @param root0.id
  * @param root0.created_at
  * @param root0.usage
+ * @param root0.finished_at
+ * @param root0.finished_reason
+ * @param root0.structured_output
  * @returns A Msg object with role 'assistant'.
  */
 export function AssistantMsg({
     name,
     content,
-    metadata = {},
-    id = crypto.randomUUID(),
-    created_at = new Date().toISOString(),
+    metadata,
+    id,
+    created_at,
     usage,
+    finished_at,
+    finished_reason,
+    structured_output,
 }: {
     name: string;
     content: string | ContentBlock[];
-    metadata?: Record<string, JSONSerializableObject>;
-    id?: string;
-    created_at?: string;
-    usage?: Msg['usage'];
+    metadata?: Record<string, JSONSerializableObject> | null;
+    id?: string | null;
+    created_at?: string | null;
+    usage?: UsageInput | null;
+    finished_at?: string | null;
+    finished_reason?: ReplyFinishedReason | null;
+    structured_output?: Msg['structured_output'];
 }): Msg {
-    return createMsg({ name, content, role: 'assistant', metadata, id, created_at, usage });
+    return createMsg({
+        name,
+        content,
+        role: 'assistant',
+        metadata: metadata ?? {},
+        id: id || _generateId(),
+        created_at: created_at || _generateTimestamp(),
+        usage,
+        finished_at,
+        finished_reason,
+        structured_output,
+    });
 }
 
 /**
@@ -201,31 +270,36 @@ export function AssistantMsg({
  * @param root0.id
  * @param root0.created_at
  * @param root0.finished_at
+ * @param root0.finished_reason
  * @returns A Msg object with role 'system'.
  */
 export function SystemMsg({
     name,
     content,
-    metadata = {},
-    id = crypto.randomUUID(),
-    created_at = new Date().toISOString(),
+    metadata,
+    id,
+    created_at,
     finished_at,
+    finished_reason,
 }: {
     name: string;
     content: string | ContentBlock[];
-    metadata?: Record<string, JSONSerializableObject>;
-    id?: string;
-    created_at?: string;
+    metadata?: Record<string, JSONSerializableObject> | null;
+    id?: string | null;
+    created_at?: string | null;
     finished_at?: string | null;
+    finished_reason?: ReplyFinishedReason | null;
 }): Msg {
+    const actualCreatedAt = created_at || _generateTimestamp();
     return createMsg({
         name,
         content,
         role: 'system',
-        metadata,
-        id,
-        created_at,
-        finished_at: finished_at ?? created_at,
+        metadata: metadata ?? {},
+        id: id || _generateId(),
+        created_at: actualCreatedAt,
+        finished_at: finished_at ?? actualCreatedAt,
+        finished_reason,
     });
 }
 
@@ -246,6 +320,21 @@ export function getTextContent(msg: Msg, separator: string = '\n'): string | nul
 }
 
 /**
+ * Check whether a message contains any block of the requested type.
+ * @param msg
+ * @param blockType
+ * @returns Whether a matching block exists.
+ */
+export function hasContentBlocks(
+    msg: Msg,
+    blockType?: ContentBlockType | ContentBlockType[] | null
+): boolean {
+    if (blockType == null) return msg.content.length > 0;
+    const blockTypes = Array.isArray(blockType) ? blockType : [blockType];
+    return msg.content.some(block => blockTypes.includes(block.type));
+}
+
+/**
  * Return all content blocks from a message, regardless of type.
  *
  * When `content` is a plain string it is wrapped in a single {@link TextBlock}.
@@ -260,12 +349,14 @@ export function getContentBlocks(msg: Msg, blockType: 'hint'): HintBlock[];
 export function getContentBlocks(msg: Msg, blockType: 'data'): DataBlock[];
 export function getContentBlocks(msg: Msg, blockType: 'tool_call'): ToolCallBlock[];
 export function getContentBlocks(msg: Msg, blockType: 'tool_result'): ToolResultBlock[];
+export function getContentBlocks(msg: Msg, blockType: ContentBlockType[]): ContentBlock[];
 export function getContentBlocks(
     msg: Msg,
-    blockType?: 'text' | 'thinking' | 'hint' | 'data' | 'tool_call' | 'tool_result'
+    blockType?: ContentBlockType | ContentBlockType[] | null
 ): ContentBlock[] {
-    if (!blockType) return msg.content;
-    return msg.content.filter(block => block.type === blockType);
+    if (blockType == null) return msg.content;
+    const blockTypes = Array.isArray(blockType) ? blockType : [blockType];
+    return msg.content.filter(block => blockTypes.includes(block.type));
 }
 
 /**
@@ -305,12 +396,7 @@ export function appendEvent(msg: Msg, event: AgentEvent): Msg {
             break;
 
         case EventType.TEXT_BLOCK_START:
-            msg.content.push({
-                type: 'text',
-                id: event.block_id,
-                text: '',
-                created_at: event.created_at,
-            });
+            msg.content.push(TextBlock({ id: event.block_id, text: '' }));
             break;
 
         case EventType.TEXT_BLOCK_DELTA: {
@@ -334,12 +420,7 @@ export function appendEvent(msg: Msg, event: AgentEvent): Msg {
         }
 
         case EventType.THINKING_BLOCK_START:
-            msg.content.push({
-                type: 'thinking',
-                id: event.block_id,
-                thinking: '',
-                created_at: event.created_at,
-            });
+            msg.content.push(ThinkingBlock({ id: event.block_id, thinking: '' }));
             break;
 
         case EventType.THINKING_BLOCK_DELTA: {
@@ -365,25 +446,23 @@ export function appendEvent(msg: Msg, event: AgentEvent): Msg {
         case EventType.HINT_BLOCK: {
             // Hint blocks are not streamed — the full content arrives in
             // a single event and is appended as a complete HintBlock.
-            const hintBlock: HintBlock = {
-                type: 'hint',
+            const hintBlock = HintBlock({
                 id: event.block_id,
                 hint: event.hint,
                 source: event.source ?? null,
-                created_at: event.created_at,
-                finished_at: event.created_at,
-            };
+            });
+            hintBlock.finished_at = hintBlock.created_at;
             msg.content.push(hintBlock);
             break;
         }
 
         case EventType.DATA_BLOCK_START:
-            msg.content.push({
-                type: 'data',
-                id: event.block_id,
-                source: { type: 'base64', data: '', media_type: event.media_type },
-                created_at: event.created_at,
-            });
+            msg.content.push(
+                DataBlock({
+                    id: event.block_id,
+                    source: Base64Source({ data: '', media_type: event.media_type }),
+                })
+            );
             break;
 
         case EventType.DATA_BLOCK_DELTA: {
@@ -417,14 +496,13 @@ export function appendEvent(msg: Msg, event: AgentEvent): Msg {
         }
 
         case EventType.TOOL_CALL_START:
-            msg.content.push({
-                type: 'tool_call',
-                id: event.tool_call_id,
-                name: event.tool_call_name,
-                input: '',
-                state: 'pending',
-                created_at: event.created_at,
-            });
+            msg.content.push(
+                ToolCallBlock({
+                    id: event.tool_call_id,
+                    name: event.tool_call_name,
+                    input: '',
+                })
+            );
             break;
 
         case EventType.TOOL_CALL_DELTA: {
@@ -448,14 +526,13 @@ export function appendEvent(msg: Msg, event: AgentEvent): Msg {
         }
 
         case EventType.TOOL_RESULT_START:
-            msg.content.push({
-                type: 'tool_result',
-                id: event.tool_call_id,
-                name: event.tool_call_name,
-                output: [],
-                state: 'running',
-                created_at: event.created_at,
-            });
+            msg.content.push(
+                ToolResultBlock({
+                    id: event.tool_call_id,
+                    name: event.tool_call_name,
+                    output: [],
+                })
+            );
             break;
 
         case EventType.TOOL_RESULT_TEXT_DELTA: {
@@ -465,23 +542,11 @@ export function appendEvent(msg: Msg, event: AgentEvent): Msg {
             } else {
                 const trb = block as ToolResultBlock;
                 if (typeof trb.output === 'string') {
-                    trb.output = [
-                        {
-                            type: 'text',
-                            id: crypto.randomUUID(),
-                            text: trb.output,
-                            created_at: event.created_at,
-                        },
-                    ];
+                    trb.output = [TextBlock({ text: trb.output })];
                 }
                 const last = trb.output[trb.output.length - 1];
                 if (!last || last.type !== 'text') {
-                    trb.output.push({
-                        type: 'text',
-                        id: crypto.randomUUID(),
-                        text: event.delta,
-                        created_at: event.created_at,
-                    });
+                    trb.output.push(TextBlock({ text: event.delta }));
                 } else {
                     (last as TextBlock).text += event.delta;
                 }
@@ -496,25 +561,13 @@ export function appendEvent(msg: Msg, event: AgentEvent): Msg {
             } else {
                 const trb = block as ToolResultBlock;
                 if (typeof trb.output === 'string') {
-                    trb.output = [
-                        {
-                            type: 'text',
-                            id: crypto.randomUUID(),
-                            text: trb.output,
-                            created_at: event.created_at,
-                        },
-                    ];
+                    trb.output = [TextBlock({ text: trb.output })];
                 }
                 const source: Base64Source | URLSource =
                     event.data != null
-                        ? { type: 'base64', data: event.data, media_type: event.media_type }
-                        : { type: 'url', url: event.url!, media_type: event.media_type };
-                trb.output.push({
-                    type: 'data',
-                    id: event.block_id ?? crypto.randomUUID(),
-                    source,
-                    created_at: event.created_at,
-                });
+                        ? Base64Source({ data: event.data, media_type: event.media_type })
+                        : URLSource({ url: event.url!, media_type: event.media_type });
+                trb.output.push(DataBlock({ id: event.block_id ?? _generateId(), source }));
             }
             break;
         }
@@ -525,7 +578,7 @@ export function appendEvent(msg: Msg, event: AgentEvent): Msg {
                 console.warn(`ToolResultBlock "${event.tool_call_id}" not found, skipping.`);
             } else {
                 (block as ToolResultBlock).state = event.state;
-                (block as ToolResultBlock).metadata = event.metadata;
+                (block as ToolResultBlock).metadata = event.metadata ?? {};
                 (block as ToolResultBlock).finished_at = event.created_at;
             }
             // The paired ToolCallBlock's lifecycle ends with its
@@ -542,10 +595,14 @@ export function appendEvent(msg: Msg, event: AgentEvent): Msg {
             if (msg.usage) {
                 msg.usage.input_tokens += event.input_tokens;
                 msg.usage.output_tokens += event.output_tokens;
+                msg.usage.cache_input_tokens += event.cache_input_tokens ?? 0;
+                msg.usage.cache_creation_input_tokens += event.cache_creation_input_tokens ?? 0;
             } else {
                 msg.usage = {
                     input_tokens: event.input_tokens,
                     output_tokens: event.output_tokens,
+                    cache_input_tokens: event.cache_input_tokens ?? 0,
+                    cache_creation_input_tokens: event.cache_creation_input_tokens ?? 0,
                 };
             }
             break;

--- a/packages/agentscope/src/message/schema.ts
+++ b/packages/agentscope/src/message/schema.ts
@@ -1,0 +1,173 @@
+import { z } from 'zod';
+
+import { ErrorType, ReplyFinishedReason } from '../type';
+import {
+    Base64Source,
+    DataBlock,
+    HintBlock,
+    TextBlock,
+    ThinkingBlock,
+    ToolCallBlock,
+    ToolResultBlock,
+    URLSource,
+} from './block';
+import type { ContentBlock } from './block';
+import { createMsg } from './message';
+import type { Msg } from './message';
+
+const entityFields = {
+    id: z.string().optional(),
+    created_at: z.string().optional(),
+    finished_at: z.string().nullable().optional(),
+};
+
+const jsonRecordSchema = z.record(z.string(), z.json());
+
+/** Runtime schema for Python-compatible text blocks. */
+export const TextBlockSchema = z
+    .object({
+        type: z.literal('text'),
+        text: z.string(),
+        ...entityFields,
+    })
+    .transform(value => TextBlock(value));
+
+/** Runtime schema for thinking blocks, including provider-specific fields. */
+export const ThinkingBlockSchema = z
+    .object({
+        type: z.literal('thinking'),
+        thinking: z.string(),
+        ...entityFields,
+    })
+    .passthrough()
+    .transform(value => ThinkingBlock(value));
+
+/** Runtime schema for inline base64 sources. */
+export const Base64SourceSchema = z
+    .object({
+        type: z.literal('base64'),
+        data: z.string(),
+        media_type: z.string(),
+    })
+    .transform(value => Base64Source(value));
+
+/** Runtime schema for URL sources. */
+export const URLSourceSchema = z
+    .object({
+        type: z.literal('url'),
+        url: z.url(),
+        media_type: z.string(),
+    })
+    .transform(value => URLSource(value));
+
+export const DataSourceSchema = z.union([Base64SourceSchema, URLSourceSchema]);
+
+/** Runtime schema for binary data blocks. */
+export const DataBlockSchema = z
+    .object({
+        type: z.literal('data'),
+        source: DataSourceSchema,
+        name: z.string().nullable().optional(),
+        ...entityFields,
+    })
+    .transform(value => DataBlock(value));
+
+const hintContentSchema = z.union([
+    z.string(),
+    z.array(z.union([TextBlockSchema, DataBlockSchema])),
+]);
+
+/** Runtime schema for one-shot hint blocks. */
+export const HintBlockSchema = z
+    .object({
+        type: z.literal('hint'),
+        hint: hintContentSchema,
+        source: z.string().nullable().optional(),
+        ...entityFields,
+    })
+    .transform(value => HintBlock(value));
+
+/** Runtime schema for tool-call blocks. */
+export const ToolCallBlockSchema = z
+    .object({
+        type: z.literal('tool_call'),
+        id: z.string(),
+        name: z.string(),
+        input: z.string(),
+        state: z.enum(['pending', 'asking', 'allowed', 'submitted', 'finished']).optional(),
+        suggested_rules: z.array(z.unknown()).optional(),
+        created_at: z.string().optional(),
+        finished_at: z.string().nullable().optional(),
+    })
+    .transform(value => ToolCallBlock(value as Parameters<typeof ToolCallBlock>[0]));
+
+/** Runtime schema for tool-result blocks. */
+export const ToolResultBlockSchema = z
+    .object({
+        type: z.literal('tool_result'),
+        id: z.string(),
+        name: z.string(),
+        output: z.union([z.string(), z.array(z.union([TextBlockSchema, DataBlockSchema]))]),
+        state: z.enum(['success', 'error', 'interrupted', 'denied', 'running']).optional(),
+        metadata: z.record(z.string(), z.unknown()).optional(),
+        created_at: z.string().optional(),
+        finished_at: z.string().nullable().optional(),
+    })
+    .transform(value => ToolResultBlock(value));
+
+/** Runtime schema for all message content blocks. */
+export const ContentBlockSchema = z.union([
+    TextBlockSchema,
+    ThinkingBlockSchema,
+    HintBlockSchema,
+    ToolCallBlockSchema,
+    ToolResultBlockSchema,
+    DataBlockSchema,
+]);
+
+export const UsageSchema = z.object({
+    input_tokens: z.number().int(),
+    output_tokens: z.number().int(),
+    cache_input_tokens: z.number().int().default(0),
+    cache_creation_input_tokens: z.number().int().default(0),
+});
+
+export const MsgSchema = z
+    .object({
+        name: z.string(),
+        content: z.array(ContentBlockSchema),
+        role: z.enum(['user', 'assistant', 'system']),
+        id: z.string().optional(),
+        metadata: jsonRecordSchema.optional(),
+        created_at: z.string().optional(),
+        usage: UsageSchema.nullable().optional(),
+        finished_at: z.string().nullable().optional(),
+        finished_reason: z.nativeEnum(ReplyFinishedReason).nullable().optional(),
+        structured_output: jsonRecordSchema.nullable().optional(),
+        error: z
+            .object({
+                type: z.nativeEnum(ErrorType).default(ErrorType.UNKNOWN),
+                message: z.string(),
+            })
+            .nullable()
+            .optional(),
+    })
+    .transform(value => createMsg(value));
+
+/**
+ * Parse an untrusted snake_case content-block payload.
+ * @param input
+ * @returns A validated content block.
+ */
+export function parseContentBlock(input: unknown): ContentBlock {
+    return ContentBlockSchema.parse(input) as ContentBlock;
+}
+
+/**
+ * Parse an untrusted snake_case message payload.
+ * @param input
+ * @returns A validated message.
+ */
+export function parseMsg(input: unknown): Msg {
+    return MsgSchema.parse(input) as Msg;
+}

--- a/packages/agentscope/src/type/index.ts
+++ b/packages/agentscope/src/type/index.ts
@@ -8,6 +8,44 @@ export type JSONSerializableObject =
     | JSONSerializableObject[]
     | { [key: string]: JSONSerializableObject };
 
+/** The reason a reply finished. */
+export enum ReplyFinishedReason {
+    COMPLETED = 'completed',
+    INTERRUPTED = 'interrupted',
+    EXCEED_MAX_ITERS = 'exceed_max_iters',
+    ERROR = 'error',
+}
+
+/** Classification of a fatal error that terminated a reply. */
+export enum ErrorType {
+    AUTHENTICATION = 'authentication',
+    PERMISSION = 'permission',
+    RATE_LIMIT = 'rate_limit',
+    INVALID_REQUEST = 'invalid_request',
+    UPSTREAM = 'upstream',
+    CONNECTION = 'connection',
+    INTERNAL = 'internal',
+    SETUP = 'setup',
+    UNKNOWN = 'unknown',
+}
+
+/** Structured, UI-facing description of a fatal reply error. */
+export class ErrorInfo {
+    type: ErrorType;
+    message: string;
+
+    /**
+     * Create error information.
+     * @param options Error fields.
+     * @param options.message Sanitized message.
+     * @param options.type Stable classification.
+     */
+    constructor({ message, type = ErrorType.UNKNOWN }: { message: string; type?: ErrorType }) {
+        this.type = type;
+        this.message = message;
+    }
+}
+
 export type ToolName = string;
 export type ToolChoice = 'auto' | 'none' | 'required' | ToolName;
 


### PR DESCRIPTION
## Linked Issues

- Related to #49

## Description

AgentScope Python models messages and content blocks as validated runtime entities. The TypeScript package previously exposed mostly structural interfaces, so default fields and serialized payload handling could differ between the two SDKs.

This PR aligns the public message behavior while retaining TypeScript-native APIs:

- Add factory functions for every content block with Python-compatible IDs, timestamps, states, and nullable fields.
- Align `Msg`, `Usage`, `UserMsg`, `AssistantMsg`, and `SystemMsg` defaults with Python.
- Add `hasContentBlocks` and list-based filtering to match Python message helpers.
- Add Zod schemas and `parseMsg` / `parseContentBlock` for validated wire payloads.
- Accumulate all four Python usage counters from model events.
- Place reply termination and error contracts in the shared type layer to avoid duplicating them between messages and events.
- Update the agent and desktop consumers for the normalized nullable fields.

No generated parity inventory, migration tooling, or internal development documentation is included.

### Verification

```bash
pnpm --filter @agentscope-ai/agentscope build
pnpm --filter @agentscope-ai/agentscope exec jest --runInBand
pnpm build:desktop
```

Results:

- Core ESM, CommonJS, and declaration builds passed.
- 19 test suites and 128 tests passed.
- Desktop type checks and production build passed.
- ESLint, Prettier, and `git diff --check` passed for all changed files.

## Checklist

- [x] This PR is linked to a related issue (see above)
- [x] Code has been formatted with `pnpm format`
- [x] Related documentation has been updated (public API JSDoc; no guide changes required)
- [x] All tests are passing (`pnpm test`)
- [x] Code is ready for review
